### PR TITLE
added relative IRI Template support

### DIFF
--- a/lib/middleware/iriTemplate.js
+++ b/lib/middleware/iriTemplate.js
@@ -3,68 +3,168 @@ const clownface = require('clownface')
 const { Router } = require('express')
 const ns = require('@tpluscode/rdf-ns-builders')
 const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
+const TermMap = require('@rdfjs/term-map')
 const { toStream } = require('rdf-dataset-ext')
 const uriTemplateRoute = require('uri-template-route')
+const uriTemplate = require('uri-templates')
 
-function middleware ({ dataset, term, graph }) {
+function prepareMap ({ dataset, term, graph }) {
   const iriTemplateNode = clownface({ dataset, term, graph })
   const template = iriTemplateNode.out(ns.hydra.template).value
 
   if (!template) {
     debug(`ignore ${term.value} because it has no hydra:template property`)
 
-    return (req, res, next) => next
+    return null
   }
 
-  const variablePropertyMap = new Map()
+  const map = new Map()
 
   iriTemplateNode.out(ns.hydra.mapping).forEach(mapping => {
     const variable = mapping.out(ns.hydra.variable).value
     const property = mapping.out(ns.hydra.property).term
 
-    variablePropertyMap.set(variable, property)
+    map.set(variable, property)
   })
 
+  return { template, map }
+}
+
+function attachDataset ({ req, map }) {
+  // do nothing if the request has a body
+  if (req.get('content-type')) {
+    return
+  }
+
+  const subject = rdf.blankNode()
+  const dataset = rdf.dataset()
+
+  Object.entries(req.params).forEach(([key, value]) => {
+    const property = map.get(key)
+
+    if (!property) {
+      return
+    }
+
+    dataset.add(rdf.quad(subject, property, rdf.literal(value)))
+  })
+
+  if (dataset.size === 0) {
+    return
+  }
+
+  req.dataset = () => {
+    return Promise.resolve(dataset)
+  }
+
+  req.quadStream = () => {
+    return toStream(dataset)
+  }
+}
+
+function absoluteMiddleware ({ dataset, term, graph }) {
+  const { template, map } = prepareMap({ dataset, term, graph })
+
+  if (!template) {
+    debug(`ignore ${term.value} because it has no hydra:template property`)
+
+    return
+  }
+
+  if (!template.startsWith('/')) {
+    debug(`ignore ${term.value} because it is a relative template`)
+
+    return
+  }
+
   return uriTemplateRoute(template, (req, res, next) => {
-    // do nothing if the request has a body
-    if (req.get('content-type')) {
-      return next()
-    }
-
-    const subject = rdf.blankNode()
-    const dataset = rdf.dataset()
-
-    Object.entries(req.params).forEach(([key, value]) => {
-      const property = variablePropertyMap.get(key)
-
-      if (!property) {
-        return
-      }
-
-      dataset.add(rdf.quad(subject, property, rdf.literal(value)))
-    })
-
-    req.dataset = () => {
-      return Promise.resolve(dataset)
-    }
-
-    req.quadStream = () => {
-      return toStream(dataset)
-    }
+    attachDataset({ req, map })
 
     next()
   })
 }
 
-function factory ({ dataset, graph }) {
+function absolute ({ dataset, graph }) {
   const node = clownface({ dataset, graph })
   const router = new Router()
 
   node.has(ns.rdf.type, ns.hydra.IriTemplate).forEach(iriTemplateNode => {
-    router.use(middleware(iriTemplateNode))
+    const middleware = absoluteMiddleware(iriTemplateNode)
+
+    if (middleware) {
+      router.use(middleware)
+    }
   })
 
   return router
 }
 
-module.exports = factory
+function relativeMiddleware ({ dataset, term, graph }) {
+  const { template: templateString, map } = prepareMap({ dataset, term, graph })
+
+  if (!templateString) {
+    debug(`ignore ${term.value} because it has no hydra:template property`)
+
+    return
+  }
+
+  if (templateString.startsWith('/')) {
+    debug(`ignore ${term.value} because it is an absolute template`)
+
+    return
+  }
+
+  const template = uriTemplate(templateString)
+
+  return (req, res, next) => {
+    const search = `?${req.url.split('?')[1] || ''}`
+
+    if (!search) {
+      return next()
+    }
+
+    if (!template.test(search)) {
+      return next()
+    }
+
+    req.params = template.fromUri(search)
+
+    attachDataset({ req, map })
+
+    next()
+  }
+}
+
+function relative ({ dataset, graph }) {
+  const node = clownface({ dataset, graph })
+  const middlewares = new TermMap()
+
+  node.has(ns.rdf.type, ns.hydra.IriTemplate).forEach(iriTemplateNode => {
+    iriTemplateNode.in(ns.hydra.search).forEach(classNode => {
+      const middleware = relativeMiddleware(iriTemplateNode)
+
+      if (middleware) {
+        middlewares.set(classNode.term, middleware)
+      }
+    })
+  })
+
+  return (req, res, next) => {
+    const filtered = [...req.hydra.resource.types].map(type => middlewares.get(type)).filter(Boolean)
+
+    if (filtered.length === 0) {
+      return next()
+    }
+
+    if (filtered.length > 1) {
+      return next(new Error(`no unique IRI Template found for: <${req.hydra.term.value}>`))
+    }
+
+    filtered[0](req, res, next)
+  }
+}
+
+module.exports = {
+  absolute,
+  relative
+}

--- a/middleware.js
+++ b/middleware.js
@@ -58,7 +58,7 @@ function middleware (api, { baseIriFromRequest, loader, store } = {}) {
 
   router.use(rdfHandler({ baseIriFromRequest }))
   router.use(waitFor(init, () => apiHeader(api)))
-  router.use(waitFor(init, () => iriTemplate(api)))
+  router.use(waitFor(init, () => iriTemplate.absolute(api)))
 
   if (loader) {
     router.use(resource({ loader }))
@@ -68,6 +68,7 @@ function middleware (api, { baseIriFromRequest, loader, store } = {}) {
     throw new Error('no loader or store provided')
   }
 
+  router.use(waitFor(init, () => iriTemplate.relative(api)))
   router.use(waitFor(init, () => operation(api)))
 
   return router

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@rdfjs/dataset": "^1.0.1",
     "@rdfjs/express-handler": "^1.1.0",
     "@rdfjs/namespace": "^1.1.0",
+    "@rdfjs/term-map": "^1.0.0",
     "@rdfjs/term-set": "^1.0.0",
     "@tpluscode/rdf-ns-builders": "^0.1.0",
     "absolute-url": "^1.2.2",
@@ -35,7 +36,8 @@
     "rdf-loaders-registry": "^0.2.0",
     "rdf-utils-fs": "^2.1.0",
     "set-link": "^1.0.0",
-    "uri-template-route": "^1.0.0"
+    "uri-template-route": "^1.0.0",
+    "uri-templates": "^0.2.0"
   },
   "devDependencies": {
     "@zazuko/rdf-vocabularies": "^2019.10.22",

--- a/test/iriTemplate.test.js
+++ b/test/iriTemplate.test.js
@@ -3,145 +3,36 @@ const express = require('express')
 const { describe, it } = require('mocha')
 const { fromStream } = require('rdf-dataset-ext')
 const rdf = { ...require('@rdfjs/data-model'), ...require('@rdfjs/dataset') }
+const namespace = require('@rdfjs/namespace')
+const TermSet = require('@rdfjs/term-set')
 const request = require('supertest')
 const iriTemplateMappingBuilder = require('./support/iriTemplateMappingBuilder')
-const middleware = require('../lib/middleware/iriTemplate')
+const { absolute, relative } = require('../lib/middleware/iriTemplate')
+
+const ex = namespace('http://example.org/')
 
 describe('middleware/iriTemplate', () => {
-  it('should be a function', () => {
-    strictEqual(typeof middleware, 'function')
-  })
-
-  it('should return a middleware function', () => {
-    const instance = middleware(iriTemplateMappingBuilder({ template: '/' }))
-
-    strictEqual(typeof instance, 'function')
-    strictEqual(instance.length, 3)
-  })
-
-  it('should do nothing if the template doesn\'t match', async () => {
-    let dataset = true
-    let quadStream = true
-    const app = express()
-
-    app.use(middleware(iriTemplateMappingBuilder({ template: '/test' })))
-
-    app.use((req, res, next) => {
-      dataset = req.dataset
-      quadStream = req.quadStream
-
-      next()
+  describe('absolute', () => {
+    it('should be a function', () => {
+      strictEqual(typeof absolute, 'function')
     })
 
-    await request(app).get('/')
+    it('should return a middleware function', () => {
+      const instance = absolute(iriTemplateMappingBuilder({ template: '/' }))
 
-    strictEqual(typeof dataset, 'undefined')
-    strictEqual(typeof quadStream, 'undefined')
-  })
-
-  it('should add all templates in the dataset', async () => {
-    const datasets = {}
-    const app = express()
-
-    const { dataset } = iriTemplateMappingBuilder({ template: '/1' })
-    iriTemplateMappingBuilder({ dataset, template: '/2' })
-
-    app.use(middleware({ dataset }))
-
-    app.use((req, res, next) => {
-      datasets[req.url] = req.dataset
-
-      next()
+      strictEqual(typeof instance, 'function')
+      strictEqual(instance.length, 3)
     })
 
-    await request(app).get('/1')
-    await request(app).get('/2')
-
-    strictEqual(typeof datasets['/1'], 'function')
-    strictEqual(typeof datasets['/2'], 'function')
-  })
-
-  it('should only handle the templates in the given graph', async () => {
-    const datasets = {}
-    const app = express()
-
-    // create two templates, one in the default graph, the other in a named graph
-    const { dataset } = iriTemplateMappingBuilder({ template: '/1' })
-
-    const api = iriTemplateMappingBuilder({
-      dataset,
-      graph: rdf.namedNode('http://example.org/graph'),
-      template: '/2'
-    })
-
-    app.use(middleware(api))
-
-    app.use((req, res, next) => {
-      datasets[req.url] = req.dataset
-
-      next()
-    })
-
-    await request(app).get('/1')
-    await request(app).get('/2')
-
-    strictEqual(typeof datasets['/1'], 'undefined')
-    strictEqual(typeof datasets['/2'], 'function')
-  })
-
-  describe('.dataset', () => {
-    it('should attach the method to the request', async () => {
+    it('should do nothing if the template doesn\'t match', async () => {
       let dataset = true
-      const app = express()
-
-      app.use(middleware(iriTemplateMappingBuilder({ template: '/' })))
-
-      app.use((req, res, next) => {
-        dataset = req.dataset
-
-        next()
-      })
-
-      await request(app).get('/')
-
-      strictEqual(typeof dataset, 'function')
-    })
-
-    it('should return the quads for the mapping via async call', async () => {
-      let dataset = null
-      const app = express()
-      const fromQuad = rdf.quad(rdf.blankNode(), rdf.namedNode('http://example.org/from'), rdf.literal('abc'))
-      const toQuad = rdf.quad(rdf.blankNode(), rdf.namedNode('http://example.org/to'), rdf.literal('xyz'))
-
-      app.use(middleware(iriTemplateMappingBuilder({
-        template: '/{?from,to}',
-        variables: {
-          from: 'http://example.org/from',
-          to: 'http://example.org/to'
-        }
-      })))
-
-      app.use(async (req, res, next) => {
-        dataset = await req.dataset()
-
-        next()
-      })
-
-      await request(app).get('/?from=abc&to=xyz')
-
-      strictEqual(dataset.match(null, fromQuad.predicate, fromQuad.object).size, 1)
-      strictEqual(dataset.match(null, toQuad.predicate, toQuad.object).size, 1)
-    })
-  })
-
-  describe('.quadStream', () => {
-    it('should attach the method to the request', async () => {
       let quadStream = true
       const app = express()
 
-      app.use(middleware(iriTemplateMappingBuilder({ template: '/' })))
+      app.use(absolute(iriTemplateMappingBuilder({ template: '/test' })))
 
       app.use((req, res, next) => {
+        dataset = req.dataset
         quadStream = req.quadStream
 
         next()
@@ -149,33 +40,449 @@ describe('middleware/iriTemplate', () => {
 
       await request(app).get('/')
 
-      strictEqual(typeof quadStream, 'function')
+      strictEqual(typeof dataset, 'undefined')
+      strictEqual(typeof quadStream, 'undefined')
     })
 
-    it('should return the quads for the mapping via async call', async () => {
-      let dataset = null
+    it('should add all templates in the dataset', async () => {
+      const datasets = {}
       const app = express()
-      const fromQuad = rdf.quad(rdf.blankNode(), rdf.namedNode('http://example.org/from'), rdf.literal('abc'))
-      const toQuad = rdf.quad(rdf.blankNode(), rdf.namedNode('http://example.org/to'), rdf.literal('xyz'))
 
-      app.use(middleware(iriTemplateMappingBuilder({
-        template: '/{?from,to}',
+      const { dataset } = iriTemplateMappingBuilder({
+        template: '/1{?test}',
         variables: {
-          from: 'http://example.org/from',
-          to: 'http://example.org/to'
+          test: ex.test
         }
-      })))
+      })
 
-      app.use(async (req, res, next) => {
-        dataset = await fromStream(rdf.dataset(), req.quadStream())
+      iriTemplateMappingBuilder({
+        dataset,
+        template: '/2{?test}',
+        variables: {
+          test: ex.test
+        }
+      })
+
+      app.use(absolute({ dataset }))
+
+      app.use((req, res, next) => {
+        datasets[req.url] = req.dataset
 
         next()
       })
 
-      await request(app).get('/?from=abc&to=xyz')
+      await request(app).get('/1?test=1')
+      await request(app).get('/2?test=2')
 
-      strictEqual(dataset.match(null, fromQuad.predicate, fromQuad.object).size, 1)
-      strictEqual(dataset.match(null, toQuad.predicate, toQuad.object).size, 1)
+      strictEqual(typeof datasets['/1?test=1'], 'function')
+      strictEqual(typeof datasets['/2?test=2'], 'function')
+    })
+
+    it('should only handle the templates in the given graph', async () => {
+      const datasets = {}
+      const app = express()
+
+      // create two templates, one in the default graph, the other in a named graph
+      const { dataset } = iriTemplateMappingBuilder({
+        template: '/1{?test}',
+        variables: {
+          test: ex.test
+        }
+      })
+
+      const api = iriTemplateMappingBuilder({
+        dataset,
+        graph: ex.graph,
+        template: '/2{?test}',
+        variables: {
+          test: ex.test
+        }
+      })
+
+      app.use(absolute(api))
+
+      app.use((req, res, next) => {
+        datasets[req.url] = req.dataset
+
+        next()
+      })
+
+      await request(app).get('/1?test=1')
+      await request(app).get('/2?test=2')
+
+      strictEqual(typeof datasets['/1?test=1'], 'undefined')
+      strictEqual(typeof datasets['/2?test=2'], 'function')
+    })
+
+    describe('.dataset', () => {
+      it('should attach the method to the request', async () => {
+        let dataset = true
+        const app = express()
+
+        app.use(absolute(iriTemplateMappingBuilder({
+          template: '/{?test}',
+          variables: {
+            test: ex.test
+          }
+        })))
+
+        app.use((req, res, next) => {
+          dataset = req.dataset
+
+          next()
+        })
+
+        await request(app).get('/?test=1')
+
+        strictEqual(typeof dataset, 'function')
+      })
+
+      it('should return the quads for the mapping via async call', async () => {
+        let dataset = null
+        const app = express()
+        const fromQuad = rdf.quad(rdf.blankNode(), ex.from, rdf.literal('abc'))
+        const toQuad = rdf.quad(rdf.blankNode(), ex.to, rdf.literal('xyz'))
+
+        app.use(absolute(iriTemplateMappingBuilder({
+          template: '/{?from,to}',
+          variables: {
+            from: 'http://example.org/from',
+            to: 'http://example.org/to'
+          }
+        })))
+
+        app.use(async (req, res, next) => {
+          dataset = await req.dataset()
+
+          next()
+        })
+
+        await request(app).get('/?from=abc&to=xyz')
+
+        strictEqual(dataset.match(null, fromQuad.predicate, fromQuad.object).size, 1)
+        strictEqual(dataset.match(null, toQuad.predicate, toQuad.object).size, 1)
+      })
+    })
+
+    describe('.quadStream', () => {
+      it('should attach the method to the request', async () => {
+        let quadStream = true
+        const app = express()
+
+        app.use(absolute(iriTemplateMappingBuilder({
+          template: '/{?test}',
+          variables: {
+            test: ex.test
+          }
+        })))
+
+        app.use((req, res, next) => {
+          quadStream = req.quadStream
+
+          next()
+        })
+
+        await request(app).get('/?test=1')
+
+        strictEqual(typeof quadStream, 'function')
+      })
+
+      it('should return the quads for the mapping via async call', async () => {
+        let dataset = null
+        const app = express()
+        const fromQuad = rdf.quad(rdf.blankNode(), ex.from, rdf.literal('abc'))
+        const toQuad = rdf.quad(rdf.blankNode(), ex.to, rdf.literal('xyz'))
+
+        app.use(absolute(iriTemplateMappingBuilder({
+          template: '/{?from,to}',
+          variables: {
+            from: 'http://example.org/from',
+            to: 'http://example.org/to'
+          }
+        })))
+
+        app.use(async (req, res, next) => {
+          dataset = await fromStream(rdf.dataset(), req.quadStream())
+
+          next()
+        })
+
+        await request(app).get('/?from=abc&to=xyz')
+
+        strictEqual(dataset.match(null, fromQuad.predicate, fromQuad.object).size, 1)
+        strictEqual(dataset.match(null, toQuad.predicate, toQuad.object).size, 1)
+      })
+    })
+  })
+
+  describe('relative', () => {
+    it('should be a function', () => {
+      strictEqual(typeof relative, 'function')
+    })
+
+    it('should return a middleware function', () => {
+      const instance = relative(iriTemplateMappingBuilder({ template: '{?test}' }))
+
+      strictEqual(typeof instance, 'function')
+      strictEqual(instance.length, 3)
+    })
+
+    it('should do nothing if the template doesn\'t match', async () => {
+      let dataset = true
+      let quadStream = true
+      const app = express()
+
+      app.use((req, res, next) => {
+        req.hydra = {
+          resource: {
+            types: new TermSet([ex.Type])
+          }
+        }
+
+        next()
+      })
+
+      app.use(relative(iriTemplateMappingBuilder({ type: ex.Type, template: '{?test}' })))
+
+      app.use((req, res, next) => {
+        dataset = req.dataset
+        quadStream = req.quadStream
+
+        next()
+      })
+
+      await request(app).get('/?other=1')
+
+      strictEqual(typeof dataset, 'undefined')
+      strictEqual(typeof quadStream, 'undefined')
+    })
+
+    it('should do nothing if the type doesn\'t match', async () => {
+      let dataset = true
+      let quadStream = true
+      const app = express()
+
+      app.use((req, res, next) => {
+        req.hydra = {
+          resource: {
+            types: new TermSet([ex.TypeA])
+          }
+        }
+
+        next()
+      })
+
+      app.use(relative(iriTemplateMappingBuilder({
+        type: ex.TypeB,
+        template: '{?test}',
+        variables: {
+          test: ex.test
+        }
+      })))
+
+      app.use((req, res, next) => {
+        dataset = req.dataset
+        quadStream = req.quadStream
+
+        next()
+      })
+
+      await request(app).get('/?test=1')
+
+      strictEqual(typeof dataset, 'undefined')
+      strictEqual(typeof quadStream, 'undefined')
+    })
+
+    it('should only handle the templates in the given graph', async () => {
+      const datasets = {}
+      const app = express()
+
+      // create two templates, one in the default graph, the other in a named graph
+      const { dataset } = iriTemplateMappingBuilder({
+        type: ex.Type,
+        template: '{?test1}',
+        variables: {
+          test1: ex.test
+        }
+      })
+
+      const api = iriTemplateMappingBuilder({
+        dataset,
+        graph: ex.graph,
+        type: ex.Type,
+        template: '{?test2}',
+        variables: {
+          test2: ex.test
+        }
+      })
+
+      app.use((req, res, next) => {
+        req.hydra = {
+          resource: {
+            types: new TermSet([ex.Type])
+          }
+        }
+
+        next()
+      })
+
+      app.use(relative(api))
+
+      app.use((req, res, next) => {
+        datasets[req.url] = req.dataset
+
+        next()
+      })
+
+      await request(app).get('/?test1=1')
+      await request(app).get('/?test2=2')
+
+      strictEqual(typeof datasets['/?test1=1'], 'undefined')
+      strictEqual(typeof datasets['/?test2=2'], 'function')
+    })
+
+    describe('.dataset', () => {
+      it('should attach the method to the request', async () => {
+        let dataset = true
+        const app = express()
+
+        app.use((req, res, next) => {
+          req.hydra = {
+            resource: {
+              types: new TermSet([ex.Type])
+            }
+          }
+
+          next()
+        })
+
+        app.use(relative(iriTemplateMappingBuilder({
+          type: ex.Type,
+          template: '{?test}',
+          variables: {
+            test: ex.test
+          }
+        })))
+
+        app.use((req, res, next) => {
+          dataset = req.dataset
+
+          next()
+        })
+
+        await request(app).get('/?test=1')
+
+        strictEqual(typeof dataset, 'function')
+      })
+
+      it('should return the quads for the mapping via async call', async () => {
+        let dataset = null
+        const app = express()
+        const fromQuad = rdf.quad(rdf.blankNode(), ex.from, rdf.literal('abc'))
+        const toQuad = rdf.quad(rdf.blankNode(), ex.to, rdf.literal('xyz'))
+
+        app.use((req, res, next) => {
+          req.hydra = {
+            resource: {
+              types: new TermSet([ex.Type])
+            }
+          }
+
+          next()
+        })
+
+        app.use(relative(iriTemplateMappingBuilder({
+          type: ex.Type,
+          template: '{?from,to}',
+          variables: {
+            from: ex.from,
+            to: ex.to
+          }
+        })))
+
+        app.use(async (req, res, next) => {
+          dataset = await req.dataset()
+
+          next()
+        })
+
+        await request(app).get('/?from=abc&to=xyz')
+
+        strictEqual(dataset.match(null, fromQuad.predicate, fromQuad.object).size, 1)
+        strictEqual(dataset.match(null, toQuad.predicate, toQuad.object).size, 1)
+      })
+    })
+
+    describe('.quadStream', () => {
+      it('should attach the method to the request', async () => {
+        let quadStream = true
+        const app = express()
+
+        app.use((req, res, next) => {
+          req.hydra = {
+            resource: {
+              types: new TermSet([ex.Type])
+            }
+          }
+
+          next()
+        })
+
+        app.use(relative(iriTemplateMappingBuilder({
+          type: ex.Type,
+          template: '{?test}',
+          variables: {
+            test: ex.test
+          }
+        })))
+
+        app.use((req, res, next) => {
+          quadStream = req.quadStream
+
+          next()
+        })
+
+        await request(app).get('/?test=1')
+
+        strictEqual(typeof quadStream, 'function')
+      })
+
+      it('should return the quads for the mapping via async call', async () => {
+        let dataset = null
+        const app = express()
+        const fromQuad = rdf.quad(rdf.blankNode(), ex.from, rdf.literal('abc'))
+        const toQuad = rdf.quad(rdf.blankNode(), ex.to, rdf.literal('xyz'))
+
+        app.use((req, res, next) => {
+          req.hydra = {
+            resource: {
+              types: new TermSet([ex.Type])
+            }
+          }
+
+          next()
+        })
+
+        app.use(relative(iriTemplateMappingBuilder({
+          type: ex.Type,
+          template: '{?from,to}',
+          variables: {
+            from: ex.from,
+            to: ex.to
+          }
+        })))
+
+        app.use(async (req, res, next) => {
+          dataset = await fromStream(rdf.dataset(), req.quadStream())
+
+          next()
+        })
+
+        await request(app).get('/?from=abc&to=xyz')
+
+        strictEqual(dataset.match(null, fromQuad.predicate, fromQuad.object).size, 1)
+        strictEqual(dataset.match(null, toQuad.predicate, toQuad.object).size, 1)
+      })
     })
   })
 })

--- a/test/support/iriTemplateMappingBuilder.js
+++ b/test/support/iriTemplateMappingBuilder.js
@@ -5,9 +5,14 @@ function iriTemplateMappingBuilder ({
   dataset = rdf.dataset(),
   term = rdf.blankNode(),
   graph = rdf.defaultGraph(),
+  type,
   template,
   variables
 } = {}) {
+  if (type) {
+    dataset.add(rdf.quad(type, ns.hydra.search, term, graph))
+  }
+
   dataset.add(rdf.quad(term, ns.rdf.type, ns.hydra.IriTemplate, graph))
 
   if (template) {
@@ -20,7 +25,7 @@ function iriTemplateMappingBuilder ({
 
       dataset.add(rdf.quad(term, ns.hydra.mapping, mapping, graph))
       dataset.add(rdf.quad(mapping, ns.hydra.variable, rdf.literal(key), graph))
-      dataset.add(rdf.quad(mapping, ns.hydra.property, rdf.namedNode(value), graph))
+      dataset.add(rdf.quad(mapping, ns.hydra.property, rdf.namedNode(value.value || value), graph))
     })
   }
 


### PR DESCRIPTION
IRI templates with a full path require to know the data and the matching paths and therefore are defined in the data. IRI templates relative to the resource avoid the problem by using only the query part and allow a more clear separation of data and API documentation. Below is an example of an API documentation for a `ObservationSet` class that uses a relative IRI template.

```turtle
<ObservationSet> a hydra:Class;
  hydra:search <observationSet#search>;
  hydra:supportedOperation <observationSet#get>.

<observationSet#get> a hydra:SupportedOperation;
  hydra:expects <TimeRange>;
  hydra:method "GET";
  hydra:returns <ObservationSet>;
  code:implementedBy [ a code:EcmaScript;
    code:link <file:./observationSet.js#get>
  ].

<observationSet#search> a hydra:IriTemplate;
  hydra:mapping [ a hydra:IriTemplateMapping;
    hydra:property <from>;
    hydra:variable "from"
  ], [ a hydra:IriTemplateMapping;
    hydra:property <to>;
    hydra:variable "to"
  ];
  hydra:template "{?from,to}";
  hydra:variableRepresentation hydra:BasicRepresentation.

<TimeRange> a hydra:Class;
  hydra:supportedProperty [
    hydra:property <from>
  ], [
    hydra:property <to>
  ].
```