### PR TITLE
fix path handling if wrapped in a router

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "10"
   - "12"
   - "14"
 after_success:

--- a/lib/middleware/apiHeader.js
+++ b/lib/middleware/apiHeader.js
@@ -1,5 +1,6 @@
-const { Router } = require('express')
+const { join } = require('path')
 const { URL } = require('url')
+const { Router } = require('express')
 
 function factory (api) {
   const router = new Router()
@@ -7,7 +8,7 @@ function factory (api) {
   router.use((req, res, next) => {
     const docUrl = new URL(req.absoluteUrl())
 
-    docUrl.pathname = api.path
+    docUrl.pathname = join(req.baseUrl, api.path)
     docUrl.search = ''
 
     res.setLink(docUrl.toString(), 'http://www.w3.org/ns/hydra/core#apiDocumentation')

--- a/lib/namespaces.js
+++ b/lib/namespaces.js
@@ -1,5 +1,6 @@
 const namespace = require('@rdfjs/namespace')
 
 module.exports = {
-  code: namespace('https://code.described.at/')
+  code: namespace('https://code.described.at/'),
+  hydra: namespace('http://www.w3.org/ns/hydra/core#')
 }

--- a/package.json
+++ b/package.json
@@ -40,12 +40,14 @@
     "uri-template-route": "^1.0.0"
   },
   "devDependencies": {
+    "@rdfjs/fetch": "^2.1.0",
     "@zazuko/rdf-vocabularies": "^2019.10.22",
     "alcaeus": "^1.0.0-beta.4",
     "codecov": "^3.6.5",
+    "express-as-promise": "0.0.2",
     "mocha": "^6.2.2",
-    "nodemon": "^2.0.3",
     "node-fetch": "^2.6.0",
+    "nodemon": "^2.0.3",
     "nyc": "^14.1.1",
     "rdf-store-fs": "^1.0.0",
     "sinon": "^9.0.2",

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -1,10 +1,20 @@
 const { describe, it, beforeEach } = require('mocha')
 const assert = require('assert')
+const { join } = require('path')
+const { URL } = require('url')
 const express = require('express')
+const { withServer } = require('express-as-promise')
 const sinon = require('sinon')
 const request = require('supertest')
+const { toCanonical } = require('rdf-dataset-ext')
 const RDF = require('@rdfjs/dataset')
+const rdfFetch = require('@rdfjs/fetch')
+const namespace = require('@rdfjs/namespace')
+const ns = require('../lib/namespaces')
+const Api = require('../Api')
 const hydraBox = require('../middleware')
+
+ns.example = namespace('http://example.org/')
 
 describe('hydra-box', () => {
   let api
@@ -99,5 +109,105 @@ describe('hydra-box', () => {
 
     // then
     assert.strictEqual(receivedResource, loadedResource)
+  })
+
+  describe('api', () => {
+    it('should use the path from the given Api object for the link header', async () => {
+      await withServer(async server => {
+        const path = '/test/api'
+        const containsPath = new RegExp(`<http://[0-9.a-z]*:[0-9]*${path}>; rel="${ns.hydra.apiDocumentation.value}"`)
+
+        server.app.use(hydraBox(new Api({ path }), {
+          loader: {
+            forClassOperation: () => [],
+            forPropertyOperation: () => []
+          }
+        }))
+
+        const url = new URL(await server.listen())
+        url.pathname = path
+
+        const res = await rdfFetch(url)
+
+        assert.match(res.headers.get('link'), containsPath)
+      })
+    })
+
+    it('should host the Api at the path given in the Api object', async () => {
+      await withServer(async server => {
+        const path = '/test/api'
+        const dataset = RDF.dataset([
+          RDF.quad(ns.example.subject, ns.example.predicate, RDF.literal('test'))
+        ])
+
+        server.app.use(hydraBox(new Api({ dataset, path }), {
+          loader: {
+            forClassOperation: () => [],
+            forPropertyOperation: () => []
+          }
+        }))
+
+        const url = new URL(await server.listen())
+        url.pathname = path
+
+        const res = await rdfFetch(url.toString())
+        const output = await res.dataset()
+
+        assert.strictEqual(toCanonical(output), toCanonical(dataset))
+      })
+    })
+
+    it('should use the path from the given Api object for the link header if it is wrapped in a router', async () => {
+      await withServer(async server => {
+        const routerPath = '/router'
+        const router = new express.Router()
+        const path = '/test/api'
+        const containsPath = new RegExp(`<http://[0-9.a-z]*:[0-9]*${join(routerPath, path)}>; rel="${ns.hydra.apiDocumentation.value}"`)
+
+        router.use(hydraBox(new Api({ path }), {
+          loader: {
+            forClassOperation: () => [],
+            forPropertyOperation: () => []
+          }
+        }))
+
+        server.app.use(routerPath, router)
+
+        const url = new URL(await server.listen())
+        url.pathname = join(routerPath, path)
+
+        const res = await rdfFetch(url)
+
+        assert.match(res.headers.get('link'), containsPath)
+      })
+    })
+
+    it('should host the Api at the path given in the Api object if it is wrapped in a router', async () => {
+      await withServer(async server => {
+        const routerPath = '/router'
+        const router = new express.Router()
+        const path = '/test/api'
+        const dataset = RDF.dataset([
+          RDF.quad(ns.example.subject, ns.example.predicate, RDF.literal('test'))
+        ])
+
+        router.use(hydraBox(new Api({ dataset, path }), {
+          loader: {
+            forClassOperation: () => [],
+            forPropertyOperation: () => []
+          }
+        }))
+
+        server.app.use(routerPath, router)
+
+        const url = new URL(await server.listen())
+        url.pathname = join(routerPath, path)
+
+        const res = await rdfFetch(url.toString())
+        const output = await res.dataset()
+
+        assert.strictEqual(toCanonical(output), toCanonical(dataset))
+      })
+    })
   })
 })


### PR DESCRIPTION
The `apiHeader` middleware used the wrong path in the link header if the middleware was wrapped in a router. This PR fixes this issue and adds tests for the link header and the hosting of the Api.