### PR TITLE
feat: add loader to req.hydra

### DIFF
--- a/lib/middleware/resource.js
+++ b/lib/middleware/resource.js
@@ -1,11 +1,11 @@
 const { debug } = require('../log')('resource')
 
-function factory ({ loader }) {
+function factory () {
   return async (req, res, next) => {
-    let resources = await loader.forClassOperation(req.hydra.term)
+    let resources = await req.hydra.loader.forClassOperation(req.hydra.term)
 
     if (resources.length === 0) {
-      resources = await loader.forPropertyOperation(req.hydra.term)
+      resources = await req.hydra.loader.forPropertyOperation(req.hydra.term)
     }
 
     if (resources.length > 1) {

--- a/middleware.js
+++ b/middleware.js
@@ -13,7 +13,7 @@ const resource = require('./lib/middleware/resource')
 const waitFor = require('./lib/middleware/waitFor')
 const StoreResourceLoader = require('./StoreResourceLoader')
 
-function middleware (api, { baseIriFromRequest, store, middleware = {}, ...options} = {} = {}) {
+function middleware (api, { baseIriFromRequest, store, middleware = {}, ...options } = {}) {
   const init = defer()
   const router = new Router()
 


### PR DESCRIPTION
I propose to have the loader also added to `req.hydra` object so that other middleware can also access it