### PR TITLE
build(deps): bump rdf-ns-builders

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@rdfjs/express-handler": "^1.2.0",
     "@rdfjs/namespace": "^1.1.0",
     "@rdfjs/term-set": "^1.0.0",
-    "@tpluscode/rdf-ns-builders": "^1.0.0",
+    "@tpluscode/rdf-ns-builders": "^2.0.0",
     "absolute-url": "^1.2.2",
     "clownface": "^1",
     "debug": "^4.1.1",


### PR DESCRIPTION
In practice, this update has no effect on JS projects, hydra-box included, unless they uses the `@tpluscode/rdf-ns-builders/strict` module which differs only in stricter TS typings.