### PR TITLE
feat: insert shorthand code implementations to API graph

### DIFF
--- a/mocha-setup.js
+++ b/mocha-setup.js
@@ -1,4 +1,6 @@
 import chai from 'chai'
+import sinonChai from 'sinon-chai'
 import rdfPlugin from 'mocha-chai-rdf/matchers.js'
 
 chai.use(rdfPlugin)
+chai.use(sinonChai)

--- a/mocha-setup.js
+++ b/mocha-setup.js
@@ -1,0 +1,4 @@
+import chai from 'chai'
+import rdfPlugin from 'mocha-chai-rdf/matchers.js'
+
+chai.use(rdfPlugin)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2368,6 +2368,16 @@
         "@rdfjs/types": "*"
       }
     },
+    "node_modules/@types/rdfjs__to-ntriples": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__to-ntriples/-/rdfjs__to-ntriples-3.0.0.tgz",
+      "integrity": "sha512-3qZGpe2L3s2fAwmLvDDrcPCVDQmmEsg1KpwDd6bLPcCWQ7BISWHIQX/k/l1VU9EZB8uNoEAcmRmeVJY2jnu7wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0"
+      }
+    },
     "node_modules/@types/rdfjs__traverser": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__traverser/-/rdfjs__traverser-0.1.5.tgz",
@@ -10986,12 +10996,16 @@
     "packages/mocha-chai-rdf": {
       "version": "0.0.0",
       "dependencies": {
+        "@rdfjs/to-ntriples": "^3.0.1",
         "@zazuko/env-node": "^2.1.3",
         "chai": "^4.5.0",
         "into-stream": "^8.0.1",
         "mocha-chai-jest-snapshot": "^1.1.4",
         "oxigraph": "^0.4.0-alpha.7",
         "stream-to-string": "^1.2.1"
+      },
+      "devDependencies": {
+        "@types/rdfjs__to-ntriples": "^3.0.0"
       }
     },
     "packages/mocha-rdf": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2405,6 +2405,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/sinon": {
+      "version": "17.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.3.tgz",
+      "integrity": "sha512-j3uovdn8ewky9kRBG19bOwaZbexJu/XjtkHyjvUgt4xfPFz18dcORIMqnYh66Fx3Powhcr85NT5+er3+oViapw==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinon-chai": {
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.12.tgz",
+      "integrity": "sha512-9y0Gflk3b0+NhQZ/oxGtaAJDvRywCa5sIyaVnounqLvmf93yBF4EgIRspePtkMs3Tr844nCclYMlcCNmLCvjuQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true
+    },
     "node_modules/@types/sparql-http-client": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/sparql-http-client/-/sparql-http-client-3.0.2.tgz",
@@ -9512,6 +9537,16 @@
         "url": "https://opencollective.com/sinon"
       }
     },
+    "node_modules/sinon-chai": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.7.0.tgz",
+      "integrity": "sha512-mf5NURdUaSdnatJx3uhoBOrY9dtL19fiOtAdT1Azxg3+lNJFiuN0uzaU3xX1LeAfL17kHQhTAJgpsfhbMJMY2g==",
+      "dev": true,
+      "peerDependencies": {
+        "chai": "^4.0.0",
+        "sinon": ">=4.0.0"
+      }
+    },
     "node_modules/sinon/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -10985,12 +11020,15 @@
         "sparql-http-client": "^3.0.0"
       },
       "devDependencies": {
+        "@types/sinon": "^17.0.3",
+        "@types/sinon-chai": "^3.2.12",
         "@types/sparql-http-client": "^3.0.0",
         "chai": "^4.5.0",
         "into-stream": "^8.0.1",
         "mocha-chai-rdf": "*",
         "oxigraph": "^0.4.0-alpha.7",
-        "sinon": "^18.0.0"
+        "sinon": "^18.0.0",
+        "sinon-chai": "^3.0.0"
       }
     },
     "packages/mocha-chai-rdf": {

--- a/packages/core/graphs/shorthands.ttl
+++ b/packages/core/graphs/shorthands.ttl
@@ -1,0 +1,10 @@
+PREFIX code: <https://code.described.at/>
+PREFIX kopflos: <https://kopflos.described.at/>
+
+kopflos:DescribeLoader
+  a code:EcmaScriptModule ;
+  code:link <node:@kopflos-cms/core/resourceLoaders.js#describe> .
+
+kopflos:OwnGraphLoader
+  a code:EcmaScriptModule ;
+  code:link <node:@kopflos-cms/core/resourceLoaders.js#fromOwnGraph> .

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,3 +1,4 @@
 export type { KopflosResponse } from './lib/Kopflos.js'
 export { default as Kopflos } from './lib/Kopflos.js'
 export { loadHandler as defaultHandlerLookup } from './lib/handler.js'
+export type { ResourceLoader } from './lib/resourceLoader.js'

--- a/packages/core/lib/Kopflos.ts
+++ b/packages/core/lib/Kopflos.ts
@@ -11,7 +11,7 @@ import type { ResourceShapeLookup, ResourceShapeMatch } from './resourceShape.js
 import defaultResourceShapeLookup from './resourceShape.js'
 import { responseOr } from './responseOr.js'
 import type { ResourceLoader, ResourceLoaderLookup } from './resourceLoader.js'
-import { fromOwnGraph, findResourceLoader } from './resourceLoader.js'
+import { insertShorthands, fromOwnGraph, findResourceLoader } from './resourceLoader.js'
 import type { Handler, HandlerLookup } from './handler.js'
 import { loadHandler } from './handler.js'
 
@@ -152,5 +152,7 @@ export default class Impl implements Kopflos {
     for await (const quad of quads) {
       kopflos.dataset.add(quad)
     }
+
+    await insertShorthands(kopflos)
   }
 }

--- a/packages/core/lib/env/KopflosNamespaceFactory.ts
+++ b/packages/core/lib/env/KopflosNamespaceFactory.ts
@@ -4,7 +4,11 @@ import type { Environment } from '@rdfjs/environment/Environment.js'
 import type NsBuildersFactory from '@tpluscode/rdf-ns-builders'
 import { code } from '@zazuko/vocabulary-extras-builders'
 
-type KopflosTerms = 'api' | 'Config' | 'Api' | 'resourceLoader' | 'handler'
+type Properties = 'api' | 'resourceLoader' | 'handler'
+type Classes = 'Config' | 'Api'
+type Shorthands = 'DescribeLoader' | 'OwnGraphLoader'
+
+export type KopflosTerms = Properties | Classes | Shorthands
 
 declare module '@tpluscode/rdf-ns-builders' {
   interface CustomNamespaces {

--- a/packages/core/lib/env/KopflosNamespaceFactory.ts
+++ b/packages/core/lib/env/KopflosNamespaceFactory.ts
@@ -4,7 +4,7 @@ import type { Environment } from '@rdfjs/environment/Environment.js'
 import type NsBuildersFactory from '@tpluscode/rdf-ns-builders'
 import { code } from '@zazuko/vocabulary-extras-builders'
 
-type Properties = 'api' | 'resourceLoader' | 'handler' | 'method'
+type Properties = 'api' | 'resourceLoader' | 'handler' | 'method' | 'config'
 type Classes = 'Config' | 'Api'
 type Shorthands = 'DescribeLoader' | 'OwnGraphLoader'
 

--- a/packages/core/lib/resourceLoader.ts
+++ b/packages/core/lib/resourceLoader.ts
@@ -2,6 +2,7 @@ import type { AnyPointer, GraphPointer } from 'clownface'
 import { isGraphPointer } from 'is-graph-pointer'
 import type { NamedNode, Stream } from '@rdfjs/types'
 import type { KopflosEnvironment } from './env/index.js'
+import type Kopflos from './Kopflos.js'
 
 export interface ResourceLoader {
   (iri: NamedNode, opts: {
@@ -43,4 +44,16 @@ export const describe: ResourceLoader = (iri, { env }) => {
 
 export const fromOwnGraph: ResourceLoader = (iri, { env }) => {
   return env.sparql.default.stream.query.construct(`CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${iri.value}> { ?s ?p ?o } }`)
+}
+
+const shorthandInserted = new WeakSet<Kopflos>()
+export async function insertShorthands(kopflos: Kopflos) {
+  if (!shorthandInserted.has(kopflos)) {
+    const { env } = kopflos
+    const shorthands = env.fromFile(new URL('../graphs/shorthands.ttl', import.meta.url))
+
+    await kopflos.dataset.import(shorthands)
+
+    shorthandInserted.add(kopflos)
+  }
 }

--- a/packages/core/lib/resourceLoader.ts
+++ b/packages/core/lib/resourceLoader.ts
@@ -18,19 +18,16 @@ export async function findResourceLoader(resourceShape: GraphPointer, env: Kopfl
 
   resourceLoader = resourceShape
     .out(env.ns.kopflos.resourceLoader)
-    .out(env.ns.code.implementedBy)
 
   if (!isGraphPointer(resourceLoader)) {
-    const api = resourceShape.in(env.ns.kopflos.api)
+    const api = resourceShape.out(env.ns.kopflos.api)
     resourceLoader = api
       .out(env.ns.kopflos.resourceLoader)
-      .out(env.ns.code.implementedBy)
 
     if (!isGraphPointer(resourceLoader)) {
       resourceLoader = api
-        .in(env.ns.kopflos.api)
+        .out(env.ns.kopflos.config)
         .out(env.ns.kopflos.resourceLoader)
-        .out(env.ns.code.implementedBy)
     }
   }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,11 +44,14 @@
     "sparql-http-client": "^3.0.0"
   },
   "devDependencies": {
+    "@types/sinon": "^17.0.3",
+    "@types/sinon-chai": "^3.2.12",
     "@types/sparql-http-client": "^3.0.0",
     "chai": "^4.5.0",
     "mocha-chai-rdf": "*",
     "oxigraph": "^0.4.0-alpha.7",
     "sinon": "^18.0.0",
+    "sinon-chai": "^3.0.0",
     "into-stream": "^8.0.1"
   },
   "mocha": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,8 @@
     "prepack": "npm run build"
   },
   "exports": {
-    "./*.js": "./*.js"
+    ".": "./index.js",
+    "./resourceLoaders.js": "./resourceLoaders.js"
   },
   "files": [
     "*.js",
@@ -53,6 +54,7 @@
   "mocha": {
     "extension": ["ts"],
     "spec": "test/**/*.test.ts",
-    "loader": "ts-node/esm"
+    "loader": "ts-node/esm",
+    "require": "../../mocha-setup.js"
   }
 }

--- a/packages/core/test/lib/Kopflos.test.ts
+++ b/packages/core/test/lib/Kopflos.test.ts
@@ -17,7 +17,7 @@ describe('lib/Kopflos', () => {
     it('initializes pointer', async function () {
       // when
       const kopflos = new Kopflos(config, {
-        dataset: this.dataset,
+        dataset: this.rdf.dataset,
       })
 
       // then
@@ -29,7 +29,7 @@ describe('lib/Kopflos', () => {
     it('returns 404 if no resource shape is found', async function () {
       // given
       const kopflos = new Kopflos(config, {
-        dataset: this.dataset,
+        dataset: this.rdf.dataset,
         resourceShapeLookup: async () => [],
       })
 
@@ -46,7 +46,7 @@ describe('lib/Kopflos', () => {
     it('returns error if no handler is found', async function () {
       // given
       const kopflos = new Kopflos(config, {
-        dataset: this.dataset,
+        dataset: this.rdf.dataset,
         resourceShapeLookup: async () => [{
           api: ex.api,
           resourceShape: ex.FooShape,
@@ -68,7 +68,7 @@ describe('lib/Kopflos', () => {
     it('returns result from handler', async function () {
       // given
       const kopflos = new Kopflos(config, {
-        dataset: this.dataset,
+        dataset: this.rdf.dataset,
         resourceShapeLookup: async () => [{
           api: ex.api,
           resourceShape: ex.FooShape,

--- a/packages/core/test/lib/Kopflos.test.ts
+++ b/packages/core/test/lib/Kopflos.test.ts
@@ -37,6 +37,7 @@ describe('lib/Kopflos', () => {
       const kopflos = new Kopflos(config, {
         dataset: this.rdf.dataset,
         resourceShapeLookup: async () => [],
+        resourceLoaderLookup: async () => () => rdf.dataset().toStream(),
       })
 
       // when
@@ -60,6 +61,7 @@ describe('lib/Kopflos', () => {
           subject: ex.foo,
         }],
         handlerLookup: async () => testHandler,
+        resourceLoaderLookup: async () => () => rdf.dataset().toStream(),
       })
 
       // when
@@ -79,7 +81,7 @@ describe('lib/Kopflos', () => {
           it('forwards core representation', async function () {
             // given
             const kopflos = new Kopflos(config, {
-              dataset: this.dataset,
+              dataset: this.rdf.dataset,
               resourceShapeLookup: async () => [{
                 api: ex.api,
                 resourceShape: ex.FooShape,
@@ -144,6 +146,7 @@ describe('lib/Kopflos', () => {
             object: ex.baz,
           }],
           handlerLookup: async () => testHandler,
+          resourceLoaderLookup: async () => () => rdf.dataset().toStream(),
         })
 
         // when
@@ -172,6 +175,7 @@ describe('lib/Kopflos', () => {
                   object: ex.baz,
                 }],
                 handlerLookup: async () => undefined,
+                resourceLoaderLookup: async () => () => rdf.dataset().toStream(),
               })
 
               // when

--- a/packages/core/test/lib/Kopflos.test.ts.trig
+++ b/packages/core/test/lib/Kopflos.test.ts.trig
@@ -15,8 +15,7 @@ ex:api2 a kopflos:Api .
 ex:FooShape
   a kopflos:ResourceShape ;
   kopflos:api ex:api1 ;
-  kopflos:resourceLoader [
-    code:implementedBy """
+  kopflos:resourceLoader """
       function(iri, { env }) {
         return env.clownface()
           .namedNode(iri)
@@ -25,5 +24,4 @@ ex:FooShape
           .toStream()
       }
     """^^code:EcmaScript ;
-  ] ;
 .

--- a/packages/core/test/lib/__snapshots__/resourceLoader.test.ts.snap
+++ b/packages/core/test/lib/__snapshots__/resourceLoader.test.ts.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lib/resourceLoader built-in loaders describe should return a stream of a DESCRIBE query 1`] = `
+"<http://example.org/foo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#label> \\"in default graph\\" .
+<http://example.org/foo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#label> \\"in graph bar\\" .
+<http://example.org/foo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#label> \\"in graph foo\\" .
+"
+`;
+
+exports[`lib/resourceLoader built-in loaders fromOwnGraph should contents of correct graph 1`] = `
+"<http://example.org/foo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#label> \\"in graph foo\\" .
+"
+`;
+
 exports[`lib/resourceLoader describe should return a stream of a DESCRIBE query 1`] = `
 "<http://example.org/foo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#label> \\"in default graph\\" .
 <http://example.org/foo> <http://www.w3.org/1999/02/22-rdf-syntax-ns#label> \\"in graph bar\\" .

--- a/packages/core/test/lib/handler.test.ts
+++ b/packages/core/test/lib/handler.test.ts
@@ -19,7 +19,7 @@ describe('lib/handler', () => {
       config = {
         codeBase: __dirname,
         sparql: {
-          default: inMemoryClients(this.store),
+          default: inMemoryClients(this.rdf),
         },
       }
     })
@@ -28,7 +28,7 @@ describe('lib/handler', () => {
       it('finds matching handler', async function () {
         // given
         const kopflos = new Kopflos(config, {
-          dataset: this.dataset,
+          dataset: this.rdf.dataset,
         })
         const match: ResourceShapeTypeMatch = {
           api: ex.api,
@@ -46,7 +46,7 @@ describe('lib/handler', () => {
       it('finds GET handler when method is HEAD', async function () {
         // given
         const kopflos = new Kopflos(config, {
-          dataset: this.dataset,
+          dataset: this.rdf.dataset,
         })
         const match: ResourceShapeTypeMatch = {
           api: ex.api,
@@ -64,7 +64,7 @@ describe('lib/handler', () => {
       it('finds handler for HEAD even if GET also exists', async function () {
         // given
         const kopflos = new Kopflos(config, {
-          dataset: this.dataset,
+          dataset: this.rdf.dataset,
         })
         const match: ResourceShapeTypeMatch = {
           api: ex.api,
@@ -82,7 +82,7 @@ describe('lib/handler', () => {
       it('finds matching handler when case does not match', async function () {
         // given
         const kopflos = new Kopflos(config, {
-          dataset: this.dataset,
+          dataset: this.rdf.dataset,
         })
         const match: ResourceShapeTypeMatch = {
           api: ex.api,
@@ -102,7 +102,7 @@ describe('lib/handler', () => {
       it('finds matching handler', async function () {
         // given
         const kopflos = new Kopflos(config, {
-          dataset: this.dataset,
+          dataset: this.rdf.dataset,
         })
         const match: ResourceShapeObjectMatch = {
           api: ex.api,
@@ -122,7 +122,7 @@ describe('lib/handler', () => {
       it('finds GET handler when method is HEAD', async function () {
         // given
         const kopflos = new Kopflos(config, {
-          dataset: this.dataset,
+          dataset: this.rdf.dataset,
         })
         const match: ResourceShapeObjectMatch = {
           api: ex.api,

--- a/packages/core/test/lib/loadApi.test.ts
+++ b/packages/core/test/lib/loadApi.test.ts
@@ -1,9 +1,12 @@
 import { createStore } from 'mocha-chai-rdf/store.js'
 import { parsingClient, streamClient } from 'mocha-chai-rdf/sparql-clients.js'
 import { expect } from 'chai'
+import rdf from '@zazuko/env-node'
+import { code } from '@zazuko/vocabulary-extras-builders'
 import type { KopflosConfig } from '../../lib/Kopflos.js'
 import Kopflos from '../../lib/Kopflos.js'
-import { ex } from '../support/ns.js'
+import { ex, kopflos } from '../support/ns.js'
+import * as resourceLoaders from '../../resourceLoaders.js'
 
 describe('loadApi', () => {
   let config: KopflosConfig
@@ -29,7 +32,7 @@ describe('loadApi', () => {
       await Kopflos.fromGraphs(kopfos, ex.PublicApi, ex.PrivateApi)
 
       // then
-      expect(kopfos.dataset).to.have.property('size', 11)
+      expect(kopfos.dataset).to.have.property('size', 15)
     })
 
     it('fetches combined graph contents (string names)', async () => {
@@ -40,7 +43,39 @@ describe('loadApi', () => {
       await Kopflos.fromGraphs(kopfos, 'http://example.org/PublicApi', 'http://example.org/PrivateApi')
 
       // then
-      expect(kopfos.dataset).to.have.property('size', 11)
+      expect(kopfos.dataset).to.have.property('size', 15)
     })
+
+    const shorthands = rdf.termMap([
+      [kopflos.DescribeLoader, resourceLoaders.describe],
+      [kopflos.OwnGraphLoader, resourceLoaders.fromOwnGraph],
+    ])
+    for (const [shorthand, implementation] of shorthands) {
+      context(`inserts ${shorthand.value} shorthand`, () => {
+        it('which has correct type', async () => {
+          // given
+          const instance = new Kopflos(config)
+
+          // when
+          await Kopflos.fromGraphs(instance, ex.PublicApi, ex.PrivateApi)
+
+          // then
+          const type = instance.graph.node(shorthand).out(rdf.ns.rdf.type)
+          expect(type).term.to.eq(code.EcmaScriptModule)
+        })
+
+        it('which can be loaded', async () => {
+          // given
+          const instance = new Kopflos(config)
+
+          // when
+          await Kopflos.fromGraphs(instance, ex.PublicApi, ex.PrivateApi)
+
+          // then
+          const loadedFunc = await instance.env.load(instance.graph.node(shorthand))
+          expect(loadedFunc).to.eq(implementation)
+        })
+      })
+    }
   })
 })

--- a/packages/core/test/lib/loadApi.test.ts
+++ b/packages/core/test/lib/loadApi.test.ts
@@ -1,5 +1,4 @@
 import { createStore } from 'mocha-chai-rdf/store.js'
-import { parsingClient, streamClient } from 'mocha-chai-rdf/sparql-clients.js'
 import { expect } from 'chai'
 import rdf from '@zazuko/env-node'
 import { code } from '@zazuko/vocabulary-extras-builders'
@@ -7,6 +6,7 @@ import type { KopflosConfig } from '../../lib/Kopflos.js'
 import Kopflos from '../../lib/Kopflos.js'
 import { ex, kopflos } from '../support/ns.js'
 import * as resourceLoaders from '../../resourceLoaders.js'
+import inMemoryClients from '../support/in-memory-clients.js'
 
 describe('loadApi', () => {
   let config: KopflosConfig
@@ -15,10 +15,7 @@ describe('loadApi', () => {
   beforeEach(function () {
     config = {
       sparql: {
-        default: {
-          parsed: parsingClient(this.store),
-          stream: streamClient(this.store),
-        },
+        default: inMemoryClients(this.rdf),
       },
     }
   })

--- a/packages/core/test/lib/resourceLoader.test.ts
+++ b/packages/core/test/lib/resourceLoader.test.ts
@@ -14,7 +14,7 @@ describe('lib/resourceLoader', () => {
   beforeEach(async function () {
     kopflos = new Kopflos({
       sparql: {
-        default: inMemoryClients(this.store),
+        default: inMemoryClients(this.rdf),
       },
     })
   })

--- a/packages/core/test/lib/resourceLoader.test.ts
+++ b/packages/core/test/lib/resourceLoader.test.ts
@@ -1,41 +1,114 @@
-import rdf from '@zazuko/env-node'
+import rdf, { Environment } from '@zazuko/env-node'
 import { expect } from 'chai'
 import { createStore } from 'mocha-chai-rdf/store.js'
+import sinon from 'sinon'
 import * as loader from '../../lib/resourceLoader.js'
 import { ex } from '../support/ns.js'
+import type { KopflosConfig } from '../../lib/Kopflos.js'
 import Kopflos from '../../lib/Kopflos.js'
 import inMemoryClients from '../support/in-memory-clients.js'
 import 'mocha-chai-rdf/snapshots.js'
+import { findResourceLoader } from '../../lib/resourceLoader.js'
+import type { KopflosEnvironment } from '../../lib/env/index.js'
+import { createEnv } from '../../lib/env/index.js'
 
 describe('lib/resourceLoader', () => {
-  beforeEach(createStore(import.meta.url, { format: 'trig', loadAll: true }))
-
-  let kopflos: Kopflos
-  beforeEach(async function () {
-    kopflos = new Kopflos({
+  function config(ctx: Mocha.Context): KopflosConfig {
+    return {
       sparql: {
-        default: inMemoryClients(this.rdf),
+        default: inMemoryClients(ctx.rdf),
       },
+    }
+  }
+
+  describe('built-in loaders', () => {
+    let kopflos: Kopflos
+
+    beforeEach(createStore(import.meta.url, { format: 'trig', loadAll: true, baseIri: ex }))
+    beforeEach(async function () {
+      kopflos = new Kopflos(config(this))
+    })
+
+    describe('describe', () => {
+      it('should return a stream of a DESCRIBE query', async () => {
+        // when
+        const dataset = await rdf.dataset().import(loader.describe(ex.foo, kopflos))
+
+        // then
+        expect(dataset).canonical.toMatchSnapshot()
+      })
+    })
+
+    describe('fromOwnGraph', () => {
+      it('should contents of correct graph', async () => {
+        // when
+        const dataset = await rdf.dataset().import(loader.fromOwnGraph(ex.foo, kopflos))
+
+        // then
+        expect(dataset).canonical.toMatchSnapshot()
+      })
     })
   })
 
-  describe('describe', () => {
-    it('should return a stream of a DESCRIBE query', async () => {
-      // when
-      const dataset = await rdf.dataset().import(loader.describe(ex.foo, kopflos))
+  describe('findResourceLoader', () => {
+    beforeEach(createStore(import.meta.url, { format: 'trig' }))
 
-      // then
-      expect(dataset).canonical.toMatchSnapshot()
+    class StubbedLoader {
+      declare load: sinon.SinonStub
+
+      init() {
+        this.load = sinon.stub()
+      }
+    }
+
+    let env: KopflosEnvironment
+    beforeEach(function () {
+      env = new Environment([StubbedLoader], { parent: createEnv(config(this)) })
     })
-  })
 
-  describe('fromOwnGraph', () => {
-    it('should contents of correct graph', async () => {
-      // when
-      const dataset = await rdf.dataset().import(loader.fromOwnGraph(ex.foo, kopflos))
+    context('when resource shape has a resource loader', () => {
+      it('it will be used', async function () {
+        // given
+        const resourceShape = this.rdf.graph.node(ex.PersonShape)
 
-      // then
-      expect(dataset).canonical.toMatchSnapshot()
+        // when
+        await findResourceLoader(resourceShape, env)
+
+        // then
+        expect(env.load).to.have.been.calledWith(sinon.match({
+          term: ex.PersonResourceLoader,
+        }))
+      })
+    })
+
+    context('when resource shape has no resource loader', () => {
+      it('API loader will be used', async function () {
+        // given
+        const resourceShape = this.rdf.graph.node(ex.PersonShape)
+
+        // when
+        await findResourceLoader(resourceShape, env)
+
+        // then
+        expect(env.load).to.have.been.calledWith(sinon.match({
+          term: ex.ApiResourceLoader,
+        }))
+      })
+    })
+
+    context('when resource shape and API have no loaders', () => {
+      it('loader from k:Config will be used', async function () {
+        // given
+        const resourceShape = this.rdf.graph.node(ex.PersonShape)
+
+        // when
+        await findResourceLoader(resourceShape, env)
+
+        // then
+        expect(env.load).to.have.been.calledWith(sinon.match({
+          term: ex.ConfigResourceLoader,
+        }))
+      })
     })
   })
 })

--- a/packages/core/test/lib/resourceLoader.test.ts.trig
+++ b/packages/core/test/lib/resourceLoader.test.ts.trig
@@ -1,3 +1,5 @@
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX kopflos: <https://kopflos.described.at/>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX ex: <http://example.org/>
 
@@ -9,4 +11,61 @@ graph ex:foo {
 
 graph ex:bar {
   ex:foo rdf:label "in graph bar".
+}
+
+GRAPH <findResourceLoader/when-resource-shape-has-a-resource-loader> {
+  ex:PersonShape
+    a kopflos:ResourceShape ;
+    kopflos:api ex:PeopleApi ;
+    sh:targetNode ex:Person ;
+    kopflos:resourceLoader ex:PersonResourceLoader ;
+  .
+
+  ex:PeopleApi
+    a kopflos:Api ;
+    kopflos:config ex:Config ;
+    kopflos:resourceLoader ex:ResourceLoader2 ;
+  .
+
+  ex:Config
+    a kopflos:Config ;
+    kopflos:resourceLoader ex:ResourceLoader3 ;
+  .
+}
+
+GRAPH <findResourceLoader/when-resource-shape-has-no-resource-loader> {
+  ex:PersonShape
+    a kopflos:ResourceShape ;
+    kopflos:api ex:PeopleApi ;
+    sh:targetNode ex:Person ;
+  .
+
+  ex:PeopleApi
+    a kopflos:Api ;
+    kopflos:config ex:Config ;
+    kopflos:resourceLoader ex:ApiResourceLoader ;
+  .
+
+  ex:Config
+    a kopflos:Config ;
+    kopflos:resourceLoader ex:ResourceLoader3 ;
+  .
+}
+
+GRAPH <findResourceLoader/when-resource-shape-and-API-have-no-loaders> {
+  ex:PersonShape
+    a kopflos:ResourceShape ;
+    kopflos:api ex:PeopleApi ;
+    sh:targetNode ex:Person ;
+  .
+
+  ex:PeopleApi
+    a kopflos:Api ;
+    kopflos:config ex:Config ;
+  .
+
+  ex:Config
+    a kopflos:Config ;
+    kopflos:resourceLoader ex:ConfigResourceLoader ;
+  .
 }

--- a/packages/core/test/lib/resourceShape.test.ts
+++ b/packages/core/test/lib/resourceShape.test.ts
@@ -14,7 +14,7 @@ describe('lib/resourceShape', () => {
   beforeEach(async function () {
     options = {
       sparql: {
-        default: inMemoryClients(this.store),
+        default: inMemoryClients(this.rdf),
       },
     }
   })

--- a/packages/core/test/support/in-memory-clients.ts
+++ b/packages/core/test/support/in-memory-clients.ts
@@ -1,10 +1,8 @@
-import type * as Oxigraph from 'oxigraph'
-import { parsingClient, streamClient } from 'mocha-chai-rdf/sparql-clients.js'
 import type { Clients } from '../../lib/env/SparqlClientFactory.js'
 
-export default function (store: Oxigraph.Store): Clients {
+export default function ({ parsingClient, streamClient }: Mocha.Context['rdf']): Clients {
   return {
-    parsed: parsingClient(store),
-    stream: streamClient(store),
+    parsed: parsingClient,
+    stream: streamClient,
   }
 }

--- a/packages/core/test/support/ns.ts
+++ b/packages/core/test/support/ns.ts
@@ -1,3 +1,6 @@
 import rdf from '@zazuko/env-node'
+import type { NamespaceBuilder } from '@rdfjs/namespace'
+import type { KopflosTerms } from '../../lib/env/KopflosNamespaceFactory.js'
 
 export const ex = rdf.namespace('http://example.org/')
+export const kopflos: NamespaceBuilder<KopflosTerms> = rdf.namespace('https://kopflos.described.at/')

--- a/packages/mocha-chai-rdf/matchers.ts
+++ b/packages/mocha-chai-rdf/matchers.ts
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Term } from '@rdfjs/types'
+import chai from 'chai'
+import type { AnyPointer } from 'clownface'
+import toNT from '@rdfjs/to-ntriples'
+
+declare global {
+  /* eslint-disable @typescript-eslint/no-namespace */
+  namespace Chai {
+    interface Assertion {
+      term: Assertion
+    }
+  }
+}
+
+const plugin: Chai.ChaiPlugin = (_chai, utils) => {
+  const Assertion = _chai.Assertion
+
+  Assertion.overwriteMethod('eq', function (_super) {
+    return function (this: any, other: Term) {
+      if (utils.flag(this, 'rdfjs-term')) {
+        const obj: AnyPointer | Term = this._obj
+
+        let term: Term
+        if ('terms' in obj) {
+          if (!obj.term) {
+            return this.assert(
+              false,
+              'expected a pointer with single term #{exp} but got #{act} terms',
+              'expected a pointer with single term not to equal #{exp}',
+              toNT(other),
+              obj.terms.length,
+            )
+          }
+
+          return this.assert(
+            other.equals(obj.term),
+            'expected a pointer to #{exp} but got #{act}',
+            'expected a pointer not to equal #{exp}',
+            toNT(other),
+            toNT(obj.term),
+          )
+        }
+
+        return this.assert(
+          other.equals(obj),
+          'expected #{this} to equal #{exp}',
+          'expected #{this} not to equal #{exp}',
+          toNT(other),
+          toNT(obj),
+        )
+      }
+
+      _super.call(this, other)
+    }
+  })
+
+  utils.addProperty(chai.Assertion.prototype, 'term', function (this: Chai.Assertion) {
+    utils.flag(this, 'rdfjs-term', true)
+  })
+}
+
+export default plugin

--- a/packages/mocha-chai-rdf/package.json
+++ b/packages/mocha-chai-rdf/package.json
@@ -3,11 +3,15 @@
   "type": "module",
   "version": "0.0.0",
   "dependencies": {
+    "@rdfjs/to-ntriples": "^3.0.1",
     "@zazuko/env-node": "^2.1.3",
     "chai": "^4.5.0",
     "into-stream": "^8.0.1",
     "mocha-chai-jest-snapshot": "^1.1.4",
     "oxigraph": "^0.4.0-alpha.7",
     "stream-to-string": "^1.2.1"
+  },
+  "devDependencies": {
+    "@types/rdfjs__to-ntriples": "^3.0.0"
   }
 }

--- a/packages/mocha-chai-rdf/store.ts
+++ b/packages/mocha-chai-rdf/store.ts
@@ -39,6 +39,9 @@ type Options = (DatasetSourceOptions | GraphSourceOptions) & {
 }
 
 export function createStore(base: string, { sliceTestPath = [1, -1], ...options }: Options = { }) {
+  const baseIRI: string | undefined = typeof options.baseIri === 'string'
+    ? options.baseIri
+    : options.baseIri?.().value
   const format = options.format ?? 'ttl'
   let loadAll = true
   let includeDefaultGraph = false
@@ -52,7 +55,9 @@ export function createStore(base: string, { sliceTestPath = [1, -1], ...options 
 
     const path = url.fileURLToPath(new url.URL(`${base}.${format}`))
 
-    let dataset: Dataset = await rdf.dataset().import(rdf.fromFile(path))
+    let dataset: Dataset = await rdf.dataset().import(rdf.fromFile(path, {
+      baseIRI,
+    }))
 
     let graph: Quad_Graph | undefined
     if (this.currentTest && !loadAll) {


### PR DESCRIPTION
This inserts nodes `kopflos:DescribeLoader` and `kopflos:OwnGraphLoader` so that end users will not have to repeat them when setting up API and Resource Shape

```
[ a code:EcmaScriptModule ;
  code:link <node:@kopflos-cms/core/resourceLoaders.js#describe> ] .
```