### PR TITLE
fix: calling next after loading API once

### DIFF
--- a/.changeset/witty-glasses-fail.md
+++ b/.changeset/witty-glasses-fail.md
@@ -1,0 +1,5 @@
+---
+"@kopflos-cms/express": patch
+---
+
+After first request, the server would stop responding

--- a/packages/express/test/index.test.ts
+++ b/packages/express/test/index.test.ts
@@ -37,6 +37,16 @@ describe('@kopflos-cms/express', () => {
         .expect(200, 'not found')
     })
 
+    it('must not stall after first request', async () => {
+      await request(app)
+        .get('/not-found')
+        .expect(404)
+
+      await request(app)
+        .get('/not-found')
+        .expect(404)
+    })
+
     context('request to resource without explicit handler', () => {
       it('should should return Core representation', async () => {
         const response = await request(app)


### PR DESCRIPTION
What a silly bug.

The first middleware was wrapped in `onetime`, which means that on subsequent requests `next()` was never called