### PR TITLE
refactor: bodies

### DIFF
--- a/.changeset/popular-lizards-cough.md
+++ b/.changeset/popular-lizards-cough.md
@@ -1,0 +1,6 @@
+---
+"@kopflos-cms/express": patch
+"@kopflos-cms/core": patch
+---
+
+Body is now always present in handler argument. Use `this.body.isRdf` to check if it can be parsed as RDF according to the Accept header. `this.body.raw` now returns the `IncomingMessage` object to allow parsing bodies using [`co-body`](https://npm.im/co-body) or similar.

--- a/package-lock.json
+++ b/package-lock.json
@@ -965,6 +965,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/@hapi/bourne": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-3.0.0.tgz",
+      "integrity": "sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -2141,6 +2148,17 @@
       "dependencies": {
         "@rdfjs/types": ">=1.0.0",
         "@types/rdfjs__environment": "*"
+      }
+    },
+    "node_modules/@types/co-body": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@types/co-body/-/co-body-6.1.3.tgz",
+      "integrity": "sha512-UhuhrQ5hclX6UJctv5m4Rfp52AfG9o9+d9/HwjxhVB5NjXxr5t9oKgJxN8xRHgr35oo8meUEHUPFWiKg6y71aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*"
       }
     },
     "node_modules/@types/connect": {
@@ -3963,6 +3981,23 @@
         "@rdfjs/data-model": "^2.0.1",
         "@rdfjs/environment": "0 - 1",
         "@rdfjs/namespace": "^2.0.0"
+      }
+    },
+    "node_modules/co-body": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/co-body/-/co-body-6.2.0.tgz",
+      "integrity": "sha512-Kbpv2Yd1NdL1V/V4cwLVxraHDV6K8ayohr2rmH0J87Er8+zJjcTa6dAn9QMPC9CRgU8+aNajKbSf1TzDB1yKPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hapi/bourne": "^3.0.0",
+        "inflation": "^2.0.0",
+        "qs": "^6.5.2",
+        "raw-body": "^2.3.3",
+        "type-is": "^1.6.16"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -6636,6 +6671,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflation": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.1.0.tgz",
+      "integrity": "sha512-t54PPJHG1Pp7VQvxyVCJ9mBbjG3Hqryges9bXoOO6GExCPa+//i/d5GSuFtpx3ALLd7lgIAur6zrIlBQyJuMlQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/inflight": {
@@ -11991,7 +12036,7 @@
     },
     "packages/core": {
       "name": "@kopflos-cms/core",
-      "version": "0.3.0-beta.4",
+      "version": "0.3.0-beta.5",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^1.1.0",
@@ -12023,10 +12068,10 @@
     },
     "packages/express": {
       "name": "@kopflos-cms/express",
-      "version": "0.0.1-beta.1",
+      "version": "0.0.1-beta.2",
       "license": "MIT",
       "dependencies": {
-        "@kopflos-cms/core": "^0.3.0-beta.2",
+        "@kopflos-cms/core": "^0.3.0-beta.5",
         "@rdfjs/express-handler": "^2.0.2",
         "@zazuko/env-node": "^2.1.3",
         "absolute-url": "^2.0.0",
@@ -12038,10 +12083,12 @@
       "devDependencies": {
         "@tpluscode/rdf-string": "^1.3.3",
         "@types/absolute-url": "^2.0.0",
+        "@types/co-body": "^6.1.3",
         "@types/express": "^4.17.21",
         "@types/rdfjs__express-handler": "^2.0.6",
         "@types/supertest": "^6.0.2",
         "chai": "^4.5.0",
+        "co-body": "^6.2.0",
         "mocha-chai-rdf": "*",
         "sinon": "^18.0.0",
         "supertest": "^7.0.0"

--- a/packages/core/lib/Kopflos.ts
+++ b/packages/core/lib/Kopflos.ts
@@ -1,6 +1,5 @@
-import type { IncomingHttpHeaders, OutgoingHttpHeaders } from 'node:http'
+import type { IncomingHttpHeaders, IncomingMessage, OutgoingHttpHeaders } from 'node:http'
 import type { parse } from 'node:querystring'
-import type { ReadableStream } from 'node:stream/web'
 import type { DatasetCore, NamedNode, Stream, Term } from '@rdfjs/types'
 import type { GraphPointer, MultiPointer } from 'clownface'
 import type { Options as EndpointOptions, StreamClient } from 'sparql-http-client/StreamClient.js'
@@ -22,10 +21,11 @@ import log from './log.js'
 type Dataset = ReturnType<KopflosEnvironment['dataset']>
 
 export interface Body<D extends DatasetCore = Dataset> {
+  isRDF: boolean
   quadStream: Stream
   dataset: Promise<D>
   pointer(): Promise<GraphPointer<NamedNode, D>>
-  raw: ReadableStream
+  raw: IncomingMessage
 }
 
 export type Query = ReturnType<typeof parse>
@@ -34,7 +34,7 @@ interface KopflosRequest<D extends DatasetCore = DatasetCore> {
   iri: NamedNode
   method: HttpMethod
   headers: IncomingHttpHeaders
-  body: Body<D> | undefined
+  body: Body<D>
   query: Query
 }
 

--- a/packages/core/test/lib/Kopflos.test.ts
+++ b/packages/core/test/lib/Kopflos.test.ts
@@ -46,7 +46,7 @@ describe('lib/Kopflos', () => {
         iri: ex.foo,
         method: 'GET',
         headers: {},
-        body: undefined,
+        body: {} as Body,
         query: {},
       })
 
@@ -72,7 +72,7 @@ describe('lib/Kopflos', () => {
         iri: ex.foo,
         method: 'GET',
         headers: {},
-        body: undefined,
+        body: {} as Body,
         query: {},
       })
 
@@ -119,7 +119,7 @@ describe('lib/Kopflos', () => {
             iri: ex.foo,
             method: 'GET',
             headers: {},
-            body: undefined,
+            body: {} as Body,
             query: {},
           })
 
@@ -130,37 +130,6 @@ describe('lib/Kopflos', () => {
     })
 
     context('body', () => {
-      it('can be undefined', async function () {
-        // given
-        const kopflos = new Kopflos(config, {
-          dataset: this.rdf.dataset,
-          resourceShapeLookup: async () => [{
-            api: ex.api,
-            resourceShape: ex.FooShape,
-            subject: ex.foo,
-          }],
-          handlerLookup: async () => ({ body }) => {
-            return {
-              status: 200,
-              body: JSON.stringify({ body: !!body }),
-            }
-          },
-          resourceLoaderLookup: async () => () => rdf.dataset().toStream(),
-        })
-
-        // when
-        const response = await kopflos.handleRequest({
-          iri: ex.foo,
-          method: 'GET',
-          headers: {},
-          body: undefined,
-          query: {},
-        })
-
-        // then
-        expect(response.body).to.deep.eq('{"body":false}')
-      })
-
       it('is forwarded to handler when defined', async function () {
         // given
         const kopflos = new Kopflos(config, {
@@ -184,7 +153,7 @@ describe('lib/Kopflos', () => {
           iri: ex.foo,
           method: 'GET',
           headers: {},
-          body: {} as unknown as Body,
+          body: {} as Body,
           query: {},
         })
 
@@ -213,7 +182,7 @@ describe('lib/Kopflos', () => {
               iri: ex.foo,
               method,
               headers: {},
-              body: undefined,
+              body: {} as Body,
               query: {},
             }) as unknown as { status: number; body: Stream }
 
@@ -244,7 +213,7 @@ describe('lib/Kopflos', () => {
               iri: ex.foo,
               method,
               headers: {},
-              body: undefined,
+              body: {} as Body,
               query: {},
             })
 
@@ -276,7 +245,7 @@ describe('lib/Kopflos', () => {
           iri: ex.baz,
           method: 'GET',
           headers: {},
-          body: undefined,
+          body: {} as Body,
           query: {},
         })
 
@@ -305,7 +274,7 @@ describe('lib/Kopflos', () => {
           iri: ex.baz,
           method: 'GET',
           headers: {},
-          body: undefined,
+          body: {} as Body,
           query: {},
         })
 
@@ -336,7 +305,7 @@ describe('lib/Kopflos', () => {
                 iri: ex.baz,
                 method,
                 headers: {},
-                body: undefined,
+                body: {} as Body,
                 query: {},
               })
 

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -31,10 +31,12 @@
   "devDependencies": {
     "@tpluscode/rdf-string": "^1.3.3",
     "@types/absolute-url": "^2.0.0",
+    "@types/co-body": "^6.1.3",
     "@types/express": "^4.17.21",
     "@types/rdfjs__express-handler": "^2.0.6",
     "@types/supertest": "^6.0.2",
     "chai": "^4.5.0",
+    "co-body": "^6.2.0",
     "mocha-chai-rdf": "*",
     "sinon": "^18.0.0",
     "supertest": "^7.0.0"

--- a/packages/express/test/BodyWrapper.test.ts
+++ b/packages/express/test/BodyWrapper.test.ts
@@ -1,18 +1,21 @@
-import { Readable } from 'node:stream'
+import { IncomingMessage } from 'node:http'
 import { expect } from 'chai'
 import sinon from 'sinon'
 import rdf from '@zazuko/env-node'
+import type { Request } from 'express'
 import { BodyWrapper } from '../BodyWrapper.js'
 import { ex } from '../../testing-helpers/ns.js'
 
 describe('BodyWrapper', () => {
+  class FakeRequest extends IncomingMessage {
+    declare quadStream: Pick<Request, 'quadStream'>['quadStream']
+  }
+
   describe('.dataset', () => {
     it('consumes stream only once', async () => {
       // given
       const quadStream = sinon.stub().returns(rdf.dataset().toStream())
-      const req = new (class extends Readable {
-        quadStream = quadStream
-      })()
+      const req = sinon.createStubInstance(FakeRequest, { quadStream })
       const body = new BodyWrapper(rdf, ex.foo, req)
 
       // when
@@ -28,9 +31,7 @@ describe('BodyWrapper', () => {
     it('consumes stream only once', async () => {
       // given
       const quadStream = sinon.stub().returns(rdf.dataset().toStream())
-      const req = new (class extends Readable {
-        quadStream = quadStream
-      })()
+      const req = sinon.createStubInstance(FakeRequest, { quadStream })
       const body = new BodyWrapper(rdf, ex.foo, req)
 
       // when

--- a/packages/express/test/BodyWrapper.test.ts
+++ b/packages/express/test/BodyWrapper.test.ts
@@ -8,7 +8,15 @@ import { ex } from '../../testing-helpers/ns.js'
 
 describe('BodyWrapper', () => {
   class FakeRequest extends IncomingMessage {
-    declare quadStream: Pick<Request, 'quadStream'>['quadStream']
+    get quadStream(): Pick<Request, 'quadStream'>['quadStream'] {
+      return this._quadStream
+    }
+
+    set quadStream(value: Pick<Request, 'quadStream'>['quadStream']) {
+      this._quadStream = value
+    }
+
+    private declare _quadStream: Pick<Request, 'quadStream'>['quadStream']
   }
 
   describe('.dataset', () => {

--- a/packages/express/test/handlers/body-handler.ts
+++ b/packages/express/test/handlers/body-handler.ts
@@ -1,8 +1,11 @@
+import type { OutgoingHttpHeaders } from 'node:http'
 import type { Handler } from '@kopflos-cms/core'
 import type { DatasetCore, Stream } from '@rdfjs/types'
+import coBody from 'co-body'
 
 const handler: Handler = async function (req) {
   let body: string | DatasetCore | Stream = 'nobody'
+  const headers: OutgoingHttpHeaders = {}
   if (req.body) {
     switch (req.query.type) {
       case 'dataset':
@@ -14,12 +17,20 @@ const handler: Handler = async function (req) {
       case 'pointer':
         body = (await req.body.pointer()).dataset
         break
+      case 'json':
+        const parsed = await coBody(req.body.raw)
+        body = JSON.stringify({
+          bar: parsed.foo,
+        })
+        headers['content-type'] = 'application/json'
+        break
     }
   }
 
   return {
     status: 200,
     body,
+    headers,
   }
 }
 

--- a/packages/express/test/handlers/body-handler.ts
+++ b/packages/express/test/handlers/body-handler.ts
@@ -17,12 +17,13 @@ const handler: Handler = async function (req) {
       case 'pointer':
         body = (await req.body.pointer()).dataset
         break
-      case 'json':
+      case 'json': {
         const parsed = await coBody(req.body.raw)
         body = JSON.stringify({
           bar: parsed.foo,
         })
         headers['content-type'] = 'application/json'
+      }
         break
     }
   }

--- a/packages/express/test/index.test.ts
+++ b/packages/express/test/index.test.ts
@@ -153,6 +153,20 @@ describe('@kopflos-cms/express', () => {
           expect(response.text).to.eq(ntriples`<http://example.org/body-handler> ${rdf.ns.rdf.type} ${ex.Foo} .\n`.toString())
         })
       }
+
+      it('can parse body directly', async () => {
+        const { body } = await request(app)
+          .get('/body-handler')
+          .query({ type: 'json' })
+          .send({ foo: 'baz' })
+          .set('content-type', 'application/json')
+          .set('host', 'example.org')
+          .expect(200)
+
+        expect(body).to.deep.eq({
+          bar: 'baz',
+        })
+      })
     })
   })
 


### PR DESCRIPTION
Since express has no easy way to determine if a body is present in a request, I changed the behavior to always create the `body` in handler args and let the implementors worry about checking if RDF is present in the message.

For other kids of payloads, I change `body.raw` so that it can be used with `co-body` to parse in user code when necessary. This avoids baking in express `body-parser` but we may still revisit what we do here when it comes to multi-part bodies