### PR TITLE
feat: simplify endpoint intitialization

### DIFF
--- a/.changeset/hungry-rats-notice.md
+++ b/.changeset/hungry-rats-notice.md
@@ -1,0 +1,5 @@
+---
+"@kopflos-cms/core": patch
+---
+
+Allow initializing clients from one instance of `StreamClient` or `ParsingClient`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2619,9 +2619,9 @@
       "dev": true
     },
     "node_modules/@types/sparql-http-client": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/sparql-http-client/-/sparql-http-client-3.0.2.tgz",
-      "integrity": "sha512-sGQ7y+W/fhSM78vBjCuwaZPiM/UAfl5ZRmc6NoxddkqBmb5JEfUmTqts7lESzuG9XxDmLfiIXsrZjeSyDlPMlg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sparql-http-client/-/sparql-http-client-3.0.4.tgz",
+      "integrity": "sha512-FTsBWUY1XJKn8K5VQi5dfWTW+xG4aNDci9s6Y1RGl5Y300F4FH/35qQeEQo+K3aD1G/eV1FDrZa2p0UNR10GOA==",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": ">=1.0.0",
@@ -12036,7 +12036,7 @@
     },
     "packages/core": {
       "name": "@kopflos-cms/core",
-      "version": "0.3.0-beta.5",
+      "version": "0.3.0-beta.7",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/types": "^1.1.0",
@@ -12056,7 +12056,7 @@
         "@types/chai-as-promised": "^7.1.8",
         "@types/sinon": "^17.0.3",
         "@types/sinon-chai": "^3.2.12",
-        "@types/sparql-http-client": "^3.0.0",
+        "@types/sparql-http-client": "^3.0.4",
         "chai": "^4.5.0",
         "chai-as-promised": "^7.0.0",
         "into-stream": "^8.0.1",
@@ -12068,10 +12068,10 @@
     },
     "packages/express": {
       "name": "@kopflos-cms/express",
-      "version": "0.0.1-beta.2",
+      "version": "0.0.1-beta.3",
       "license": "MIT",
       "dependencies": {
-        "@kopflos-cms/core": "^0.3.0-beta.5",
+        "@kopflos-cms/core": "^0.3.0-beta.6",
         "@rdfjs/express-handler": "^2.0.2",
         "@zazuko/env-node": "^2.1.3",
         "absolute-url": "^2.0.0",

--- a/packages/core/lib/Kopflos.ts
+++ b/packages/core/lib/Kopflos.ts
@@ -6,6 +6,7 @@ import type { Options as EndpointOptions, StreamClient } from 'sparql-http-clien
 import type { ParsingClient } from 'sparql-http-client/ParsingClient.js'
 import { CONSTRUCT } from '@tpluscode/sparql-builder'
 import { IN } from '@tpluscode/sparql-builder/expressions'
+import type { Client } from 'sparql-http-client'
 import type { KopflosEnvironment } from './env/index.js'
 import { createEnv } from './env/index.js'
 import type { ResourceShapeLookup, ResourceShapeMatch } from './resourceShape.js'
@@ -57,7 +58,7 @@ interface Clients {
   parsed: ParsingClient
 }
 
-type Endpoint = string | EndpointOptions | Clients
+type Endpoint = string | EndpointOptions | Clients | Client
 
 export interface KopflosConfig {
   sparql: Record<string, Endpoint> & { default: Endpoint }
@@ -85,7 +86,13 @@ export default class Impl implements Kopflos {
 
     log.info('Kopflos initialized')
     log.debug('Options', {
-      sparqlEndpoints: Object.keys(this.env.sparql),
+      sparqlEndpoints: Object.fromEntries(Object.entries(this.env.sparql).map(([key, value]) => {
+        return [key, {
+          endpointUrl: value.parsed.endpointUrl,
+          updateUrl: value.parsed.updateUrl,
+          storeUrl: value.parsed.storeUrl,
+        }]
+      })),
       resourceShapeLookup: options.resourceShapeLookup?.name ?? 'default',
       resourceLoaderLookup: options.resourceLoaderLookup?.name ?? 'default',
       handlerLookup: options.handlerLookup?.name ?? 'default',

--- a/packages/core/lib/env/SparqlClientFactory.ts
+++ b/packages/core/lib/env/SparqlClientFactory.ts
@@ -41,8 +41,8 @@ export default class implements SparqlClientFactory {
       }
 
       const endpointConfig = {
-        factory: this,
         ...endpointOrClients,
+        factory: this,
       }
 
       return [key, {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,7 +50,7 @@
     "@types/chai-as-promised": "^7.1.8",
     "@types/sinon": "^17.0.3",
     "@types/sinon-chai": "^3.2.12",
-    "@types/sparql-http-client": "^3.0.0",
+    "@types/sparql-http-client": "^3.0.4",
     "chai": "^4.5.0",
     "chai-as-promised": "^7.0.0",
     "mocha-chai-rdf": "*",

--- a/packages/core/test/lib/env/SparqlClientFactory.test.ts
+++ b/packages/core/test/lib/env/SparqlClientFactory.test.ts
@@ -123,4 +123,63 @@ describe('lib/env/SparqlClientFactory', () => {
       expect(factory.sparql.default.parsed).to.have.property('name', 'parsed')
     })
   })
+
+  context('initialised from client single instance', () => {
+    const endpoints = {
+      endpointUrl: 'http://example.com/sparql',
+      updateUrl: 'http://example.com/update',
+      storeUrl: 'http://example.com/store',
+    }
+
+    const singleClients = [
+      ['stream client', new StreamClient(endpoints)],
+      ['parsing client', new ParsingClient(endpoints)],
+    ]
+
+    for (const [name, client] of singleClients) {
+      context(`of ${name}`, () => {
+        before(() => {
+          // given
+          const Kopflos = class implements KopflosFactory {
+            static exports = ['kopflos']
+
+            get kopflos() {
+              return {
+                config: {
+                  sparql: {
+                    default: client,
+                  },
+                },
+              }
+            }
+          }
+
+          // when
+          factory = new Environment([Kopflos, Factory], { parent: rdf })
+        })
+
+        it('sets both clients', () => {
+          // then
+          expect(factory.sparql.default.stream).to.be.ok
+          expect(factory.sparql.default.parsed).to.be.ok
+        })
+
+        it('uses same endpoint URLs for both clients', () => {
+          // then
+          expect(factory.sparql.default.stream).to.have.property('endpointUrl', 'http://example.com/sparql')
+          expect(factory.sparql.default.parsed).to.have.property('endpointUrl', 'http://example.com/sparql')
+          expect(factory.sparql.default.stream).to.have.property('updateUrl', 'http://example.com/update')
+          expect(factory.sparql.default.parsed).to.have.property('updateUrl', 'http://example.com/update')
+          expect(factory.sparql.default.stream).to.have.property('storeUrl', 'http://example.com/store')
+          expect(factory.sparql.default.parsed).to.have.property('storeUrl', 'http://example.com/store')
+        })
+
+        it('uses factory itself with sparql clients', () => {
+          // then
+          expect(factory.sparql.default.stream).to.have.property('factory', factory)
+          expect(factory.sparql.default.parsed).to.have.property('factory', factory)
+        })
+      })
+    }
+  })
 })


### PR DESCRIPTION
Further simplifies programmatic set up of SPARQL clients, only requiring one instance. The other will be created with same settings.