### PR TITLE
refactor: make a plugin for shorthand terms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16485,6 +16485,7 @@
         "is-graph-pointer": "^2.1.0",
         "is-stream": "^4.0.1",
         "middleware-async": "^1.4.0",
+        "onetime": "^7.0.0",
         "rdf-loader-code": "^2.2.0",
         "rdf-loaders-registry": "^1.0.3",
         "sparql-http-client": "^3.0.0"
@@ -16560,6 +16561,7 @@
         "anylogger": "^1.0.11"
       },
       "devDependencies": {
+        "@zazuko/env-node": "^2.1.3",
         "chai": "^5.1.1",
         "mocha-chai-rdf": "^0.1.4"
       }

--- a/packages/core/lib/resourceLoader.ts
+++ b/packages/core/lib/resourceLoader.ts
@@ -2,7 +2,6 @@ import type { AnyPointer, GraphPointer } from 'clownface'
 import { isGraphPointer } from 'is-graph-pointer'
 import type { NamedNode, Stream } from '@rdfjs/types'
 import type { KopflosEnvironment } from './env/index.js'
-import type KopflosInstance from './Kopflos.js'
 import type { Kopflos } from './Kopflos.js'
 import { logCode } from './log.js'
 
@@ -42,16 +41,4 @@ export const describe: ResourceLoader = (iri, { env }) => {
 
 export const fromOwnGraph: ResourceLoader = (iri, { env }) => {
   return env.sparql.default.stream.query.construct(`CONSTRUCT { ?s ?p ?o } WHERE { GRAPH <${iri.value}> { ?s ?p ?o } }`)
-}
-
-const shorthandInserted = new WeakSet<Kopflos>()
-export async function insertShorthands(kopflos: KopflosInstance) {
-  if (!shorthandInserted.has(kopflos)) {
-    const { env } = kopflos
-    const shorthands = env.fromFile(new URL('../graphs/shorthands.ttl', import.meta.url))
-
-    await kopflos.dataset.import(shorthands)
-
-    shorthandInserted.add(kopflos)
-  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,9 @@
   "exports": {
     ".": "./index.js",
     "./env.js": "./lib/env/index.js",
-    "./resourceLoaders.js": "./resourceLoaders.js"
+    "./resourceLoaders.js": "./resourceLoaders.js",
+    "./plugins.js": "./plugins.js",
+    "./plugin/shorthandTerms.js": "./plugin/shorthandTerms.js"
   },
   "files": [
     "*.js",
@@ -43,6 +45,7 @@
     "anylogger": "^1.0.11",
     "is-graph-pointer": "^2.1.0",
     "is-stream": "^4.0.1",
+    "onetime": "^7.0.0",
     "rdf-loader-code": "^2.2.0",
     "rdf-loaders-registry": "^1.0.3",
     "sparql-http-client": "^3.0.0"

--- a/packages/core/plugin/shorthandTerms.ts
+++ b/packages/core/plugin/shorthandTerms.ts
@@ -1,0 +1,12 @@
+import type { KopflosPlugin } from '../lib/Kopflos.js'
+
+export default function (): KopflosPlugin {
+  return {
+    async onStart(kopflos): Promise<void> {
+      const { env } = kopflos
+      const shorthands = env.fromFile(new URL('../graphs/shorthands.ttl', import.meta.url))
+
+      await kopflos.dataset.import(shorthands)
+    },
+  }
+}

--- a/packages/core/plugins.ts
+++ b/packages/core/plugins.ts
@@ -5,12 +5,21 @@ export async function loadPlugins(plugins: KopflosConfig['plugins']): Promise<Ko
   const pluginsCombined = Object.entries({
     '@kopflos-cms/core/plugin/shorthandTerms.js': {},
     ...plugins,
+  }).filter(([plugin, options]) => {
+    if (options === false) {
+      log.debug('Skipping disabled plugin', plugin)
+      return false
+    }
+
+    return true
   })
 
   return Promise.all(pluginsCombined.map(async ([plugin, options]) => {
     log.info('Loading plugin', plugin)
 
-    const pluginFactory = await import(plugin)
-    return pluginFactory.default(options)
+    const [module, exportName = 'default'] = plugin.split('#')
+
+    const pluginFactory = await import(module)
+    return pluginFactory[exportName](options)
   }))
 }

--- a/packages/core/plugins.ts
+++ b/packages/core/plugins.ts
@@ -1,0 +1,16 @@
+import log from './lib/log.js'
+import type { KopflosConfig, KopflosPlugin } from './lib/Kopflos.js'
+
+export async function loadPlugins(plugins: KopflosConfig['plugins']): Promise<KopflosPlugin[]> {
+  const pluginsCombined = Object.entries({
+    '@kopflos-cms/core/plugin/shorthandTerms.js': {},
+    ...plugins,
+  })
+
+  return Promise.all(pluginsCombined.map(async ([plugin, options]) => {
+    log.info('Loading plugin', plugin)
+
+    const pluginFactory = await import(plugin)
+    return pluginFactory.default(options)
+  }))
+}

--- a/packages/core/test/lib/loadApi.test.ts
+++ b/packages/core/test/lib/loadApi.test.ts
@@ -1,11 +1,8 @@
 import { createStore } from 'mocha-chai-rdf/store.js'
 import { expect } from 'chai'
-import rdf from '@zazuko/env-node'
-import { code } from '@zazuko/vocabulary-extras-builders'
 import type { KopflosConfig } from '../../lib/Kopflos.js'
 import Kopflos from '../../lib/Kopflos.js'
-import { ex, kopflos } from '../../../testing-helpers/ns.js'
-import * as resourceLoaders from '../../resourceLoaders.js'
+import { ex } from '../../../testing-helpers/ns.js'
 import inMemoryClients from '../../../testing-helpers/in-memory-clients.js'
 
 describe('loadApi', () => {
@@ -30,7 +27,7 @@ describe('loadApi', () => {
       await Kopflos.fromGraphs(kopfos, ex.PublicApi, ex.PrivateApi)
 
       // then
-      expect(kopfos.dataset).to.have.property('size', 15)
+      expect(kopfos.dataset).to.have.property('size', 11)
     })
 
     it('fetches combined graph contents (string names)', async () => {
@@ -41,39 +38,7 @@ describe('loadApi', () => {
       await Kopflos.fromGraphs(kopfos, 'http://example.org/PublicApi', 'http://example.org/PrivateApi')
 
       // then
-      expect(kopfos.dataset).to.have.property('size', 15)
+      expect(kopfos.dataset).to.have.property('size', 11)
     })
-
-    const shorthands = rdf.termMap([
-      [kopflos.DescribeLoader, resourceLoaders.describe],
-      [kopflos.OwnGraphLoader, resourceLoaders.fromOwnGraph],
-    ])
-    for (const [shorthand, implementation] of shorthands) {
-      context(`inserts ${shorthand.value} shorthand`, () => {
-        it('which has correct type', async () => {
-          // given
-          const instance = new Kopflos(config)
-
-          // when
-          await Kopflos.fromGraphs(instance, ex.PublicApi, ex.PrivateApi)
-
-          // then
-          const type = instance.graph.node(shorthand).out(rdf.ns.rdf.type)
-          expect(type).to.eq(code.EcmaScriptModule)
-        })
-
-        it('which can be loaded', async () => {
-          // given
-          const instance = new Kopflos(config)
-
-          // when
-          await Kopflos.fromGraphs(instance, ex.PublicApi, ex.PrivateApi)
-
-          // then
-          const loadedFunc = await instance.env.load(instance.graph.node(shorthand))
-          expect(loadedFunc).to.eq(implementation)
-        })
-      })
-    }
   })
 })

--- a/packages/core/test/plugins.test.ts
+++ b/packages/core/test/plugins.test.ts
@@ -1,3 +1,4 @@
+import url from 'node:url'
 import { expect } from 'chai'
 import { loadPlugins } from '../plugins.js'
 
@@ -9,6 +10,31 @@ describe('@kopflos-cms/core/plugins.js', () => {
 
       // then
       expect(plugins).to.have.length(1)
+    })
+
+    it('can explicitly disable plugins', async () => {
+      // when
+      const plugins = await loadPlugins({
+        '@kopflos-cms/core/plugin/shorthandTerms.js': false,
+      })
+
+      // then
+      expect(plugins).to.have.length(0)
+    })
+
+    it('allows referencing named exports', async () => {
+      // given
+      const pluginPath = url.fileURLToPath(
+        new URL('./support/plugin.js', import.meta.url),
+      ) + '#namedPlugin'
+
+      // when
+      const plugins = await loadPlugins({
+        [pluginPath]: 'foobar',
+      })
+
+      // then
+      expect(plugins[1]).to.have.property('name', 'foobar')
     })
   })
 })

--- a/packages/core/test/plugins.test.ts
+++ b/packages/core/test/plugins.test.ts
@@ -1,0 +1,14 @@
+import { expect } from 'chai'
+import { loadPlugins } from '../plugins.js'
+
+describe('@kopflos-cms/core/plugins.js', () => {
+  describe('loadPlugins', () => {
+    it('includes default plugins', async () => {
+      // when
+      const plugins = await loadPlugins({})
+
+      // then
+      expect(plugins).to.have.length(1)
+    })
+  })
+})

--- a/packages/core/test/support/plugin.ts
+++ b/packages/core/test/support/plugin.ts
@@ -1,0 +1,5 @@
+export function namedPlugin() {
+  return {
+    name: 'foobar',
+  }
+}

--- a/packages/express/index.ts
+++ b/packages/express/index.ts
@@ -8,6 +8,7 @@ import factory from '@zazuko/env-node'
 import onetime from 'onetime'
 import { match, P } from 'ts-pattern'
 import asyncMiddleware from 'middleware-async'
+import { loadPlugins } from '@kopflos-cms/core/plugins.js' // eslint-disable-line import/no-unresolved
 import { BodyWrapper } from './BodyWrapper.js'
 
 declare module 'express-serve-static-core' {
@@ -24,13 +25,13 @@ declare module '@kopflos-cms/core' {
 }
 
 export default async (options: KopflosConfig): Promise<{ middleware: RequestHandler; instance: Kopflos }> => {
-  const kopflos = new Kopflos(options)
+  const kopflos = new Kopflos(options, {
+    plugins: await loadPlugins(options.plugins),
+  })
 
   const loadApiGraphs = onetime(async (graphs: Required<KopflosConfig>['apiGraphs']) => {
     await Kopflos.fromGraphs(kopflos, ...graphs)
   })
-
-  await kopflos.loadPlugins()
 
   const middleware = Router()
 

--- a/packages/plugin-deploy-resources/index.ts
+++ b/packages/plugin-deploy-resources/index.ts
@@ -1,4 +1,4 @@
-import type { KopflosEnvironment, KopflosPlugin } from '@kopflos-cms/core'
+import type { Kopflos, KopflosPlugin } from '@kopflos-cms/core'
 import { bootstrap } from '@hydrofoil/talos-core/bootstrap.js'
 import { fromDirectories } from '@hydrofoil/talos-core'
 import { ResourcePerGraphStore } from '@hydrofoil/resource-store'
@@ -14,7 +14,7 @@ const log = (anylogger as unknown as AnyLogger<BaseLevels>)('kopflos:deploy-reso
 
 export default function kopflosPlugin({ paths = [], enabled = true }: Options = {}): Required<Pick<KopflosPlugin, 'onStart'>> {
   return {
-    async onStart(env: KopflosEnvironment) {
+    async onStart({ env }: Kopflos) {
       if (!enabled) {
         log.info('Auto deploy disabled. Skipping deployment')
         return

--- a/packages/plugin-deploy-resources/package.json
+++ b/packages/plugin-deploy-resources/package.json
@@ -19,6 +19,7 @@
     "anylogger": "^1.0.11"
   },
   "devDependencies": {
+    "@kopflos-cms/core": "*",
     "@zazuko/env-node": "^2.1.3",
     "chai": "^5.1.1",
     "mocha-chai-rdf": "^0.1.4"

--- a/packages/plugin-deploy-resources/test/index.test.ts
+++ b/packages/plugin-deploy-resources/test/index.test.ts
@@ -1,10 +1,9 @@
 import url from 'node:url'
-import type { KopflosEnvironment } from '@kopflos-cms/core'
-import { createEnv } from '@kopflos-cms/core/env.js' // eslint-disable-line import/no-unresolved
 import { createEmpty } from 'mocha-chai-rdf/store.js'
 import rdf from '@zazuko/env-node'
 import { expect, use } from 'chai'
 import snapshots from 'mocha-chai-rdf/snapshots.js'
+import Kopflos from '@kopflos-cms/core'
 import configure from '../index.js'
 import inMemoryClients from '../../testing-helpers/in-memory-clients.js'
 
@@ -14,12 +13,12 @@ const ex = rdf.namespace(baseIri + '/')
 describe('@kopflos-cms/plugin-deploy-resources', () => {
   use(snapshots)
 
-  let env: KopflosEnvironment
+  let env: Kopflos
 
   beforeEach(createEmpty)
 
   beforeEach(function () {
-    env = createEnv({
+    env = new Kopflos({
       baseIri,
       sparql: {
         default: inMemoryClients(this.rdf),


### PR DESCRIPTION
Since we now have the plugin functionality, I thought I would move the code which inserts the shorthand terms `kl:DescribeLoader` to a plugin. That made me realise too that the logic of loading plugins is unnecessarily tied to the `Kopflos` class. Instead, I moved that out and now we can initialise the instance with pre-loaded plugin. Good for testing :)